### PR TITLE
Add reader overlay debug infrastructure

### DIFF
--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -17,16 +17,19 @@
 {% endblock %}
 
 {% block content %}
-<div class="reader-container" x-data="window.createReader({ comicId: {{ comic_id }} })" tabindex="0"
+<div class="reader-container" x-data="window.parker.applyReaderOverlayEnhancements(window.createReader({ comicId: {{ comic_id }} }))" tabindex="0"
      :class="{ 'scroll-mode': isScrollMode }"
      x-on:keydown.window="handleKey($event)"
      x-on:scroll.passive="handleScroll()"
+     x-on:pointermove="overlays.handleViewportPointerMove($event)"
+     x-on:pointerleave="overlays.handlePointerLeave()"
      x-on:touchstart="handleTouchStart($event)"
      x-on:touchend="handleTouchEnd($event)">
 
     {% include "reader/partials/_toolbar.html" %}
     {% include "reader/partials/_bookmark_detour_banner.html" %}
     {% include "reader/partials/_settings_panel.html" %}
+    {% include "reader/partials/_overlay_debug_hud.html" %}
 
     <div class="hover-zone"
          x-show="readingMode === 'paged'"
@@ -43,5 +46,7 @@
 {% endblock %}
 
 {% block extra_scripts %}
+<script src="{{ url('/static/js/reader-overlays.js') }}?v={{ asset_version('static/js/reader-overlays.js') }}"></script>
 <script src="{{ url('/static/js/reader.js') }}?v={{ asset_version('static/js/reader.js') }}"></script>
+<script src="{{ url('/static/js/reader-annotations.js') }}?v={{ asset_version('static/js/reader-annotations.js') }}"></script>
 {% endblock %}

--- a/app/templates/reader/partials/_overlay_debug_controls.html
+++ b/app/templates/reader/partials/_overlay_debug_controls.html
@@ -1,0 +1,9 @@
+<button x-on:click="toggleOverlayDebug()"
+        class="p-2 text-gray-300 hover:text-white rounded hover:bg-white/10 transition-colors"
+        :class="{'text-blue-400': overlays.debug}"
+        title="Toggle Overlay Debug">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h16v16H4z" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16M4 12h16" />
+    </svg>
+</button>

--- a/app/templates/reader/partials/_overlay_debug_hud.html
+++ b/app/templates/reader/partials/_overlay_debug_hud.html
@@ -1,0 +1,6 @@
+<div
+    x-show="overlays.debug && overlays.pointerPoint"
+    x-cloak
+    class="reader-overlay-debug-hud"
+    x-text="overlays.getPointerLabel()">
+</div>

--- a/app/templates/reader/partials/_overlay_layer.html
+++ b/app/templates/reader/partials/_overlay_layer.html
@@ -1,0 +1,14 @@
+<svg
+    class="reader-overlay-layer"
+    viewBox="0 0 1 1"
+    preserveAspectRatio="none"
+    data-reader-overlay-layer
+    :data-overlay-page-index="page.index"
+    :data-overlay-interactive="overlays.interactive ? 'true' : 'false'"
+    :class="{ 'is-interactive': overlays.interactive }"
+    x-on:pointermove="overlays.handlePointerMove($event, page.index)"
+    x-on:pointerleave="overlays.handlePointerLeave()"
+    x-on:pointerdown="overlays.handlePointerDown($event, page.index)"
+    x-on:pointerup="overlays.handlePointerUp($event)"
+    x-html="overlays.renderPage(page.index)">
+</svg>

--- a/app/templates/reader/partials/_paged_content.html
+++ b/app/templates/reader/partials/_paged_content.html
@@ -1,35 +1,62 @@
 <template x-if="readingMode === 'paged'">
-    <div class="reader-content">
+    <div class="reader-content"
+         :class="{
+             'reader-content-fit-width': fitMode === 'width',
+             'cursor-pointer': fitWidthPointerZone === 'edge'
+         }"
+         x-on:click="handleFitWidthContentClick($event)"
+         x-on:mousemove="handleFitWidthPointerMove($event)"
+         x-on:mouseleave="clearFitWidthPointerZone()">
 
-        <div class="nav-zone left" x-on:click="handleZoneClick('left')"></div>
-        <div class="nav-zone center" x-on:click="handleZoneClick('center')"></div>
-        <div class="nav-zone right" x-on:click="handleZoneClick('right')"></div>
+        <div class="nav-zone left"
+             :class="{ 'reader-nav-zone-paused': overlays.isInteractive() }"
+             :style="fitMode === 'width' ? 'pointer-events: none;' : ''"
+             x-on:click="handleZoneClick('left')"></div>
+        <div class="nav-zone center"
+             :class="{ 'reader-nav-zone-paused': overlays.isInteractive() }"
+             :style="fitMode === 'width' ? 'pointer-events: none;' : ''"
+             x-on:click="handleZoneClick('center')"></div>
+        <div class="nav-zone right"
+             :class="{ 'reader-nav-zone-paused': overlays.isInteractive() }"
+             :style="fitMode === 'width' ? 'pointer-events: none;' : ''"
+             x-on:click="handleZoneClick('right')"></div>
 
-        <div class="flex items-center justify-center h-full w-full"
+        <div class="reader-page-stage flex items-center justify-center h-full w-full"
              :class="{
+                'reader-page-stage-fit-width': fitMode === 'width',
                 'flex-row': readDirection === 'ltr',
                 'flex-row-reverse': readDirection === 'rtl',
                 'gap-0': true
              }">
 
             <template x-for="(page, idx) in pagesToDisplay" :key="page.index">
-                <img
-                    :src="getPageUrl(page.index)"
-                    :class="imageClasses"
-                    class="reader-page"
-                    :class="{
-                        'object-right': viewMode === 'double' && pagesToDisplay.length > 1 && (
-                            (readDirection === 'ltr' && idx === 0) ||
-                            (readDirection === 'rtl' && idx === 1)
-                        ),
-                        'object-left': viewMode === 'double' && pagesToDisplay.length > 1 && (
-                            (readDirection === 'ltr' && idx === 1) ||
-                            (readDirection === 'rtl' && idx === 0)
-                        )
-                    }"
-                    :style="imageStyles"
-                    alt="Page"
-                >
+                <div class="reader-page-shell"
+                     data-reader-page-shell
+                     :data-page-index="page.index"
+                     :class="imageClasses"
+                     :style="imageStyles">
+                    <img
+                        :src="getPageUrl(page.index)"
+                        data-reader-page-image
+                        :class="{
+                            'object-right': viewMode === 'double' && pagesToDisplay.length > 1 && (
+                                (readDirection === 'ltr' && idx === 0) ||
+                                (readDirection === 'rtl' && idx === 1)
+                            ),
+                            'object-left': viewMode === 'double' && pagesToDisplay.length > 1 && (
+                                (readDirection === 'ltr' && idx === 1) ||
+                                (readDirection === 'rtl' && idx === 0)
+                            )
+                        }"
+                        class="reader-page reader-page-shell-image"
+                        :style="fitMode === 'width'
+                            ? { width: '100%', height: 'auto' }
+                            : { width: 'auto', height: '100%' }"
+                        alt="Page"
+                        draggable="false"
+                    >
+                    {% include "reader/partials/_overlay_layer.html" %}
+                </div>
             </template>
 
             <div class="absolute inset-y-0 left-1/2 w-24 -translate-x-1/2 pointer-events-none z-20"

--- a/app/templates/reader/partials/_scroll_content.html
+++ b/app/templates/reader/partials/_scroll_content.html
@@ -3,12 +3,17 @@
         <div class="reader-scroll-stack">
             <template x-for="page in Array.from({ length: meta.page_count }, (_, index) => ({ index }))" :key="`scroll-${page.index}`">
                 <div class="reader-scroll-page" :data-scroll-page-index="page.index">
-                    <img
-                        :src="getPageUrl(page.index)"
-                        class="reader-page reader-scroll-image"
-                        :style="scrollImageStyles"
-                        alt="Page"
-                    >
+                    <div class="reader-scroll-page-shell" data-reader-page-shell :data-page-index="page.index">
+                        <img
+                            :src="getPageUrl(page.index)"
+                            data-reader-page-image
+                            class="reader-page reader-scroll-image"
+                            :style="scrollImageStyles"
+                            alt="Page"
+                            draggable="false"
+                        >
+                        {% include "reader/partials/_overlay_layer.html" %}
+                    </div>
                 </div>
             </template>
         </div>

--- a/app/templates/reader/partials/_styles.html
+++ b/app/templates/reader/partials/_styles.html
@@ -45,10 +45,107 @@
         overflow: hidden; position: relative;
     }
 
+    .reader-content-fit-width {
+        align-items: flex-start;
+        justify-content: flex-start;
+        overflow-x: hidden;
+        overflow-y: auto;
+        overscroll-behavior-y: contain;
+    }
+
+    .reader-page-stage-fit-width {
+        align-items: flex-start !important;
+        height: auto !important;
+        min-height: 100%;
+        padding-bottom: 9rem;
+    }
+
+    .reader-content-fit-width .reader-page,
+    .reader-content-fit-width .reader-page-shell,
+    .reader-content-fit-width .reader-page-shell-image {
+        max-height: none;
+    }
+
     .reader-page {
         max-width: 100%; max-height: 100%;
         object-fit: contain;
         user-select: none;
+    }
+
+    .reader-page-shell,
+    .reader-scroll-page-shell {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 auto;
+        overflow: hidden;
+    }
+
+    .reader-page-shell-image {
+        display: block;
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+        user-select: none;
+    }
+
+    .reader-scroll-page-shell {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .reader-overlay-layer {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 10;
+        pointer-events: none;
+        overflow: visible;
+    }
+
+    .reader-overlay-layer.is-interactive,
+    .reader-overlay-layer[data-overlay-interactive="true"] {
+        pointer-events: auto;
+        touch-action: none;
+    }
+
+    .reader-overlay-debug-border {
+        stroke: rgba(251, 191, 36, 0.95);
+        stroke-width: 2;
+        stroke-dasharray: 8 5;
+    }
+
+    .reader-overlay-debug-crosshair {
+        stroke: rgba(96, 165, 250, 0.85);
+        stroke-width: 1.5;
+        stroke-dasharray: 5 5;
+    }
+
+    .reader-overlay-debug-label {
+        fill: rgba(254, 243, 199, 0.95);
+        font-size: 0.035px;
+        font-weight: 700;
+        paint-order: stroke;
+        stroke: rgba(0, 0, 0, 0.8);
+        stroke-width: 0.008px;
+    }
+
+    .reader-overlay-debug-hud {
+        position: fixed;
+        left: 1rem;
+        bottom: 1rem;
+        z-index: 70;
+        border: 1px solid rgba(251, 191, 36, 0.45);
+        border-radius: 0.5rem;
+        background: rgba(0, 0, 0, 0.78);
+        color: rgba(254, 243, 199, 0.96);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.75rem;
+        font-weight: 700;
+        padding: 0.5rem 0.75rem;
+        pointer-events: none;
     }
 
     .reader-scroll-content {
@@ -86,6 +183,10 @@
     .nav-zone {
         position: absolute; top: 0; bottom: 0; width: 20%; z-index: 20;
         cursor: pointer;
+    }
+
+    .reader-nav-zone-paused {
+        pointer-events: none;
     }
 
     .nav-zone.left { left: 0; }

--- a/app/templates/reader/partials/_toolbar.html
+++ b/app/templates/reader/partials/_toolbar.html
@@ -63,6 +63,8 @@
             </svg>
         </button>
 
+        {% include "reader/partials/_overlay_debug_controls.html" %}
+
         <button x-on:click="toggleFullscreen()" class="p-2 text-gray-300 hover:text-white rounded hover:bg-white/10" title="Toggle Fullscreen (f)">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />

--- a/docs/reader-annotation-overlays-scope.md
+++ b/docs/reader-annotation-overlays-scope.md
@@ -1,0 +1,371 @@
+# Reader Annotation Overlays Scope
+
+Status: Planning / foundational branch
+
+This note captures the product and technical direction discussed before the `feature/reader-overlay-layer` branch started. The immediate goal is not to ship full annotations in one pass. The goal is to establish a page-scoped SVG overlay foundation that can support a future annotation system without tying the reader to one annotation implementation.
+
+## Why This Exists
+
+Parker already has reader bookmarks, bookmark detours, context-aware reader navigation, paged and long-view reading modes, double-page spreads, manga/RTL behavior, and per-comic reader overrides. Those features make page-specific reader state useful, but they also mean visual annotations must be designed carefully.
+
+A simple `notes` field on bookmarks would be useful, but it would mostly be `Bookmarks 2.0`: save this page and optionally explain why. That is not the same thing as a real annotation system.
+
+A robust annotation system should let a user attach commentary or visual markup to a comic page or, later, a page region/panel, whether or not that page is bookmarked.
+
+## Product Framing
+
+Recommended concept split:
+
+- **Bookmark:** I want to come back to this page.
+- **Annotation:** I have something to say about this page or part of this page.
+- **Overlay:** The reader infrastructure that renders page-relative visual layers above comic images.
+
+This keeps annotations separate from bookmarks while still allowing the future annotation implementation to reuse bookmark patterns such as user ownership, comic access checks, age-rating checks, incognito restrictions, page validation, modal/panel behavior, and list/create/update/delete API shapes.
+
+## Core Decisions
+
+### Use SVG Exclusively
+
+Use SVG for visual overlays instead of `<canvas>`.
+
+Reasons:
+
+- SVG provides native primitives for annotation shapes: `path`, `rect`, `circle`, `line`, `polyline`, `g`, and `title`.
+- Saved annotations remain individually selectable and editable in the DOM.
+- Hit testing, hover/selected states, labels, and accessibility affordances are easier than with canvas.
+- SVG scales cleanly across fit modes and screen sizes when driven by normalized coordinates.
+- Parker does not need heavy bitmap-style drawing in the first pass.
+
+Avoid exotic SVG features for the first version. Prefer simple, broadly supported primitives and avoid filters, masks, embedded HTML, `foreignObject`, and complex text layout until there is a concrete need.
+
+### Do Not Modify Comic Archives
+
+Annotations should be stored as Parker-side user data, not written back into CBZ/CBR archives or `ComicInfo.xml`.
+
+Parker's filesystem/archive content remains the source of truth for comic metadata and page images. User-specific annotation state belongs in Parker's database, similar to reading progress and bookmarks.
+
+Future export/import can use a sidecar JSON format, but archive mutation should stay out of scope.
+
+### Page-Scoped Overlays, Not One Global Overlay
+
+Each rendered comic page should own its own SVG overlay layer.
+
+Preferred structure:
+
+```html
+<div class="reader-page-shell" data-page-index="12">
+  <img class="reader-page-image" src="...">
+  <svg
+    class="reader-overlay-layer"
+    data-overlay-page-index="12"
+    viewBox="0 0 1 1"
+    preserveAspectRatio="none">
+  </svg>
+</div>
+```
+
+This is important because Parker can render one page, two pages, or many scrolled pages. A per-page overlay keeps all coordinates relative to the source page image instead of the reader viewport or spread.
+
+### Normalized Coordinates
+
+Store and render overlay geometry in normalized page coordinates, not screen pixels.
+
+Examples:
+
+```json
+{
+  "type": "rect",
+  "page_index": 12,
+  "x": 0.18,
+  "y": 0.32,
+  "width": 0.25,
+  "height": 0.12
+}
+```
+
+```json
+{
+  "type": "path",
+  "page_index": 12,
+  "points": [
+    [0.12, 0.20],
+    [0.14, 0.23],
+    [0.17, 0.25]
+  ],
+  "stroke_width": 0.004
+}
+```
+
+The overlay system should provide shared helpers for converting browser pointer coordinates into normalized page coordinates. Annotation tools should not each reinvent coordinate mapping.
+
+## Future Overlay System Possibilities
+
+The overlay system should be generic enough to support more than annotations, but these should be treated as possible future consumers rather than committed roadmap items.
+
+| Overlay Type | Purpose | Notes |
+| --- | --- | --- |
+| **Annotations** | Pins, boxes, freehand paths, and notes | The first real consumer and the reason for the foundational branch. |
+| **Reading focus mask** | Dim everything except a panel or region | Could support distraction-free guided reading or accessibility experiments. |
+| **Panel guide** | Show manually marked panel order | Useful if Parker ever explores guided panel-by-panel reading without OCR. |
+| **Admin/debug overlay** | Show image bounds, page index, aspect ratio, detected landscape pages, or coordinate readouts | Useful during development and for diagnosing reader layout issues. |
+| **Search/OCR results** | Highlight text regions from future OCR/search work | Explicitly out of scope now, but page overlays would be the natural rendering layer. |
+| **Presentation mode** | Temporary laser-pointer-style marks during screen sharing | Could be session-only and non-persisted. |
+| **Page issue markers** | Flag corrupt areas, bad crops, missing pages, or other page-level quality concerns | Could support future admin cleanup/reporting workflows. |
+
+The practical near-term secondary consumer is the admin/debug overlay. It can validate page bounds, normalized coordinates, and pointer mapping before persisted annotation tools exist.
+
+## Reader Mode Implications
+
+### Single-Page Mode
+
+This is the simplest case: one rendered page image and one overlay layer for the current page.
+
+### Double-Page Mode
+
+Each displayed page must keep its own overlay layer. Do not render one overlay across the full spread, because each page has a separate coordinate space.
+
+Manga/RTL mode may change display order and navigation direction, but annotation coordinates must still belong to the source page image.
+
+### Long View / Scroll Mode
+
+Each scroll-rendered page should have its own shell and overlay. The overlay should scroll naturally with its page.
+
+This mode creates the biggest interaction challenge on touch devices because drag gestures can mean either scroll the reader or draw/edit an annotation.
+
+## Interaction Model
+
+The reader should have a clear distinction between read mode and annotation/overlay interaction mode.
+
+In read mode:
+
+- overlays can be visible
+- annotations can be passive/selectable if safe
+- normal reader taps, swipes, keyboard shortcuts, and scrolling should continue to work
+
+In annotation mode:
+
+- overlay layers can capture pointer events
+- drawing and shape placement are enabled
+- reader navigation gestures should be suppressed or reduced while interacting
+- an explicit Done/Exit action should return to reading
+
+This is especially important on mobile, where tap, swipe, drag, and scroll gestures overlap heavily.
+
+## Form Factor Considerations
+
+Desktop is the easiest target because mouse input is precise, hover states are available, and keyboard shortcuts can support power-user flows.
+
+Tablet and stylus should be a strong target for drawing annotations, but touch interactions need large controls and forgiving hit areas.
+
+Phone support should be cautious. Basic viewing, pin placement, rectangle placement, and annotation editing are reasonable. Full freehand drawing in long view on a phone may be frustrating and can be deferred.
+
+Recommended support level for early iterations:
+
+| Form Factor | Support Level |
+| --- | --- |
+| Desktop mouse | Full support |
+| Tablet touch/stylus | Good support |
+| Phone | Basic support |
+| Phone long-view freehand drawing | Defer or treat as experimental |
+
+## Likely Annotation Feature Levels
+
+### Level 1: Page Text Annotations
+
+Simple page-attached notes. Useful, but visually close to bookmark notes if implemented alone.
+
+### Level 2: Pins and Rectangles
+
+A strong first visual annotation release. Users can point to a spot or draw a rectangular region and attach optional title/body text.
+
+This feels meaningfully different from bookmarks without taking on the full complexity of freehand drawing.
+
+### Level 3: Freehand SVG Paths
+
+A pen tool that records pointer movement as normalized points and renders it as SVG paths.
+
+This requires stroke simplification, undo/cancel behavior, pointer capture, mobile gesture handling, and careful interaction design.
+
+### Level 4: OCR/Text Highlighting
+
+Out of scope for now. Comics are image-based, so true text highlighting would require OCR and introduces accuracy, performance, language, and storage concerns.
+
+## Proposed Code Separation
+
+Use three reader-side JavaScript files:
+
+- `static/js/reader.js`
+- `static/js/reader-overlays.js`
+- `static/js/reader-annotations.js`
+
+Responsibilities:
+
+### `reader.js`
+
+Owns the existing reader state, navigation, progress, bookmarks, settings, launch context, and mode transitions.
+
+It should integrate with overlays at a high level only:
+
+- initialize overlay state
+- expose current page/page metadata as needed
+- ask overlays whether interactive mode is active
+- suppress reader gestures when overlay interactions are active
+
+### `reader-overlays.js`
+
+Owns generic overlay infrastructure:
+
+- overlay state factory
+- active overlay mode/tool state
+- page-relative coordinate mapping
+- pointer routing
+- renderer registry
+- debug overlay support
+- helpers for grouping overlay items by page
+
+It should not know Parker annotation persistence details.
+
+### `reader-annotations.js`
+
+Owns the annotation domain and tools:
+
+- annotation item shape conventions
+- annotation renderers
+- select/pin/rectangle/pen tools
+- future API integration
+- future annotation panel interactions
+
+The foundational branch can include a placeholder/stub file so the separation exists from the start, even if persisted annotations are not implemented yet.
+
+## Suggested Overlay Item Shape
+
+Generic overlay item:
+
+```json
+{
+  "id": "annotation-123",
+  "type": "annotation",
+  "page_index": 12,
+  "shape": {
+    "kind": "rect",
+    "x": 0.2,
+    "y": 0.3,
+    "width": 0.25,
+    "height": 0.12
+  }
+}
+```
+
+The generic overlay system should care about `type` and `page_index`. The type-specific renderer should care about annotation details.
+
+## Future Server-Side Annotation Model
+
+A future annotation model could look like:
+
+```python
+class Annotation(Base):
+    id
+    user_id
+    comic_id
+    page_index
+    kind          # note, pin, rectangle, freehand
+    title
+    body
+    color
+    anchor_json   # normalized position/shape/strokes
+    created_at
+    updated_at
+```
+
+Candidate API shape:
+
+```text
+GET    /api/annotations/comic/{comic_id}
+GET    /api/annotations/comic/{comic_id}/page/{page_index}
+POST   /api/annotations/comic/{comic_id}
+PATCH  /api/annotations/{annotation_id}
+DELETE /api/annotations/{annotation_id}
+```
+
+This is not part of the foundational overlay branch unless deliberately expanded.
+
+## Initial Branch Scope
+
+`feature/reader-overlay-layer` should focus on the backbone:
+
+- add `static/js/reader-overlays.js`
+- add `static/js/reader-annotations.js` as a future annotation integration point
+- add per-page SVG overlay layer partials
+- wire overlay layers into paged mode and long-view mode
+- load overlay scripts before `reader.js`
+- initialize generic overlay state from the reader
+- add normalized coordinate mapping helpers
+- add an optional debug overlay to validate alignment and pointer mapping
+- suppress or short-circuit reader gestures while overlays are in interactive mode
+
+No database annotation model, annotation API, or persisted annotation UI is required for this first pass.
+
+## Non-Goals For The Foundational Branch
+
+Out of scope:
+
+- adding a real `Annotation` database model
+- adding annotation API endpoints
+- saving annotations
+- modifying bookmarks
+- adding OCR or text selection
+- writing annotations into comic archives
+- building a generalized plugin marketplace for reader overlays
+- fully solving mobile freehand drawing UX
+- adding sharing/public annotation behavior
+
+## Risks And Guardrails
+
+### Coordinate Mapping
+
+This is the most important technical risk. Pointer coordinates must be mapped to the actual rendered image bounds, not just the container or viewport.
+
+The implementation should account for:
+
+- image bounding boxes
+- letterboxing from fit modes
+- scroll position
+- double-page layouts
+- mobile viewport sizes
+- device pixel ratio only where relevant
+
+### Reader Gesture Conflicts
+
+Annotation mode must not fight with page taps, swipe navigation, long-view scrolling, keyboard shortcuts, or bookmark/goto/settings modals.
+
+### Over-Abstraction
+
+The overlay system should be generic enough to support annotations and debug overlays, but it should not become a large plugin framework before there are multiple real consumers.
+
+### Accessibility And Controls
+
+Future annotation controls should avoid hover-only behavior and should provide explicit mobile-friendly mode switching. SVG elements should be selectable and labelable where appropriate.
+
+## Recommended Implementation Phases
+
+1. **Overlay infrastructure**: per-page SVG layers, coordinate mapping, debug renderer, mode flag.
+2. **Passive visual annotations**: render mock/stub annotation items from `reader-annotations.js` without persistence.
+3. **Persisted page/pin/rectangle annotations**: add backend model/API and reader UI.
+4. **Freehand SVG path annotations**: add pen tool, stroke simplification, undo/cancel, and edit/delete behavior.
+5. **Mobile polish**: bottom-sheet controls, larger handles, touch-specific gesture refinements.
+
+## Naming
+
+Foundational branch:
+
+```text
+feature/reader-overlay-layer
+```
+
+Future feature branch candidates:
+
+```text
+feature/reader-annotations
+feature/page-annotations
+feature/annotation-drawing-tools
+```

--- a/static/js/reader-annotations.js
+++ b/static/js/reader-annotations.js
@@ -1,0 +1,139 @@
+(() => {
+    function createReaderAnnotations() {
+        return {
+            enabled: false,
+            itemsByPage: {},
+
+            getOverlayItemsByPage() {
+                return this.itemsByPage;
+            }
+        };
+    }
+
+    function overlayDebugEnabledFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get('overlay_debug') === 'true';
+    }
+
+    function shouldPauseReaderGesture(reader) {
+        return !!(reader.overlays && reader.overlays.isInteractive && reader.overlays.isInteractive());
+    }
+
+    function clickStartedOnReaderControl(event) {
+        return !!event.target.closest(
+            '.reader-toolbar, .reader-controls, .scrubber-wrapper, .settings-panel, ' +
+            '.bookmark-modal, .goto-modal, button, input, select, textarea, a, [role="button"]'
+        );
+    }
+
+    function getFitWidthNavigationZone(event) {
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+        if (viewportWidth <= 0) {
+            return null;
+        }
+
+        const xRatio = event.clientX / viewportWidth;
+        if (xRatio <= 0.2) {
+            return 'left';
+        }
+
+        if (xRatio >= 0.8) {
+            return 'right';
+        }
+
+        return 'center';
+    }
+
+    function wrapReaderGesture(reader, methodName) {
+        const originalMethod = reader[methodName];
+        if (typeof originalMethod !== 'function') {
+            return;
+        }
+
+        reader[methodName] = function wrappedReaderGesture(...args) {
+            if (shouldPauseReaderGesture(this)) {
+                return;
+            }
+
+            return originalMethod.apply(this, args);
+        };
+    }
+
+    function applyReaderOverlayEnhancements(reader) {
+        const annotations = createReaderAnnotations();
+        const overlays = window.parker.createReaderOverlayLayer({
+            debug: overlayDebugEnabledFromUrl(),
+            itemsByPage: annotations.getOverlayItemsByPage()
+        });
+
+        reader.annotations = annotations;
+        reader.overlays = overlays;
+        reader.fitWidthPointerZone = null;
+
+        reader.toggleOverlayDebug = function toggleOverlayDebug() {
+            this.overlays.toggleDebug();
+            window.parker.showToast(this.overlays.debug ? 'Overlay debug on' : 'Overlay debug off');
+        };
+
+        reader.toggleAnnotationMode = function toggleAnnotationMode() {
+            this.annotations.enabled = !this.annotations.enabled;
+            this.overlays.setActiveTool(this.annotations.enabled ? 'debug-select' : null);
+            window.parker.showToast(this.annotations.enabled ? 'Annotation mode placeholder on' : 'Annotation mode placeholder off');
+        };
+
+        reader.handleFitWidthPointerMove = function handleFitWidthPointerMove(event) {
+            if (this.readingMode !== 'paged' || this.fitMode !== 'width') {
+                this.fitWidthPointerZone = null;
+                return;
+            }
+
+            if (event.defaultPrevented || shouldPauseReaderGesture(this) || clickStartedOnReaderControl(event)) {
+                this.fitWidthPointerZone = null;
+                return;
+            }
+
+            const zone = getFitWidthNavigationZone(event);
+            this.fitWidthPointerZone = zone === 'left' || zone === 'right' ? 'edge' : null;
+        };
+
+        reader.clearFitWidthPointerZone = function clearFitWidthPointerZone() {
+            this.fitWidthPointerZone = null;
+        };
+
+        reader.handleFitWidthContentClick = function handleFitWidthContentClick(event) {
+            if (this.readingMode !== 'paged' || this.fitMode !== 'width') {
+                return;
+            }
+
+            if (event.defaultPrevented || shouldPauseReaderGesture(this) || clickStartedOnReaderControl(event)) {
+                return;
+            }
+
+            const zone = getFitWidthNavigationZone(event);
+            if (!zone) {
+                return;
+            }
+
+            this.handleZoneClick(zone);
+        };
+
+        wrapReaderGesture(reader, 'handleTouchStart');
+        wrapReaderGesture(reader, 'handleTouchEnd');
+        wrapReaderGesture(reader, 'handleZoneClick');
+
+        return reader;
+    }
+
+    function createReaderWithOverlays(options) {
+        if (typeof window.createReader !== 'function') {
+            throw new Error('Parker reader has not been loaded yet.');
+        }
+
+        return applyReaderOverlayEnhancements(window.createReader(options));
+    }
+
+    window.parker = window.parker || {};
+    window.parker.createReaderAnnotations = createReaderAnnotations;
+    window.parker.applyReaderOverlayEnhancements = applyReaderOverlayEnhancements;
+    window.createReaderWithOverlays = createReaderWithOverlays;
+})();

--- a/static/js/reader-overlays.js
+++ b/static/js/reader-overlays.js
@@ -1,0 +1,281 @@
+(() => {
+    const DEFAULT_OPTIONS = Object.freeze({
+        debug: false,
+        itemsByPage: null
+    });
+
+    function clampNormalizedValue(value) {
+        if (!Number.isFinite(value)) {
+            return 0;
+        }
+
+        return Math.max(0, Math.min(1, value));
+    }
+
+    function normalizePageIndex(pageIndex) {
+        const value = Number.parseInt(pageIndex, 10);
+        return Number.isNaN(value) ? null : value;
+    }
+
+    function getPageImage(pageShell) {
+        return pageShell?.querySelector('[data-reader-page-image]') || null;
+    }
+
+    function getPageIndexFromShell(pageShell) {
+        return normalizePageIndex(pageShell?.dataset?.pageIndex);
+    }
+
+    function getPageShellFromPoint(event) {
+        if (typeof document.elementsFromPoint !== 'function') {
+            return null;
+        }
+
+        return document.elementsFromPoint(event.clientX, event.clientY)
+            .find((element) => element.matches?.('[data-reader-page-shell]')) || null;
+    }
+
+    function normalizePointFromEvent(event, pageShell) {
+        const image = getPageImage(pageShell);
+        if (!image) {
+            return null;
+        }
+
+        const rect = image.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+            return null;
+        }
+
+        return {
+            x: clampNormalizedValue((event.clientX - rect.left) / rect.width),
+            y: clampNormalizedValue((event.clientY - rect.top) / rect.height)
+        };
+    }
+
+    function buildDebugOverlay(pageIndex) {
+        return [
+            {
+                id: `debug-border-${pageIndex}`,
+                type: 'debug-border',
+                page_index: pageIndex
+            },
+            {
+                id: `debug-crosshair-${pageIndex}`,
+                type: 'debug-crosshair',
+                page_index: pageIndex
+            },
+            {
+                id: `debug-label-${pageIndex}`,
+                type: 'debug-label',
+                page_index: pageIndex
+            }
+        ];
+    }
+
+    function renderDebugOverlay(item) {
+        if (item.type === 'debug-border') {
+            return `
+                <rect
+                    x="0.002"
+                    y="0.002"
+                    width="0.996"
+                    height="0.996"
+                    fill="none"
+                    vector-effect="non-scaling-stroke"
+                    class="reader-overlay-debug-border" />
+            `;
+        }
+
+        if (item.type === 'debug-crosshair') {
+            return `
+                <line
+                    x1="0.5"
+                    y1="0"
+                    x2="0.5"
+                    y2="1"
+                    vector-effect="non-scaling-stroke"
+                    class="reader-overlay-debug-crosshair" />
+                <line
+                    x1="0"
+                    y1="0.5"
+                    x2="1"
+                    y2="0.5"
+                    vector-effect="non-scaling-stroke"
+                    class="reader-overlay-debug-crosshair" />
+            `;
+        }
+
+        if (item.type === 'debug-label') {
+            return `
+                <text
+                    x="0.02"
+                    y="0.06"
+                    font-size="0.035"
+                    stroke-width="0.008"
+                    vector-effect="non-scaling-stroke"
+                    class="reader-overlay-debug-label">Page ${item.page_index + 1}</text>
+            `;
+        }
+
+        return '';
+    }
+
+    function createReaderOverlayLayer(options = {}) {
+        const config = { ...DEFAULT_OPTIONS, ...options };
+
+        return {
+            enabled: true,
+            debug: !!config.debug,
+            interactive: false,
+            activeTool: null,
+            pointerPageIndex: null,
+            pointerPoint: null,
+            itemsByPage: config.itemsByPage || {},
+
+            setDebug(value) {
+                this.debug = !!value;
+                if (!this.debug && !this.isInteractive()) {
+                    this.handlePointerLeave();
+                }
+            },
+
+            toggleDebug() {
+                this.setDebug(!this.debug);
+            },
+
+            setInteractive(value) {
+                this.interactive = !!value;
+            },
+
+            setActiveTool(toolName) {
+                this.activeTool = toolName || null;
+                this.setInteractive(!!toolName);
+            },
+
+            clearActiveTool() {
+                this.setActiveTool(null);
+            },
+
+            isInteractive() {
+                return this.enabled && this.interactive;
+            },
+
+            getItemsForPage(pageIndex) {
+                const normalizedPageIndex = normalizePageIndex(pageIndex);
+                if (normalizedPageIndex === null) {
+                    return [];
+                }
+
+                const items = this.itemsByPage[String(normalizedPageIndex)] || [];
+
+                if (!this.debug) {
+                    return items;
+                }
+
+                return [...items, ...buildDebugOverlay(normalizedPageIndex)];
+            },
+
+            renderItem(item) {
+                if (item.type && item.type.startsWith('debug-')) {
+                    return renderDebugOverlay(item);
+                }
+
+                return '';
+            },
+
+            renderPage(pageIndex) {
+                return this.getItemsForPage(pageIndex)
+                    .map((item) => this.renderItem(item))
+                    .join('');
+            },
+
+            pointFromEvent(event, pageShell) {
+                return normalizePointFromEvent(event, pageShell);
+            },
+
+            updatePointer(event, pageShell, pageIndex = getPageIndexFromShell(pageShell)) {
+                if (!pageShell) {
+                    return null;
+                }
+
+                const point = this.pointFromEvent(event, pageShell);
+                if (!point) {
+                    return null;
+                }
+
+                const normalizedPageIndex = normalizePageIndex(pageIndex);
+                if (normalizedPageIndex === null) {
+                    return null;
+                }
+
+                this.pointerPageIndex = normalizedPageIndex;
+                this.pointerPoint = point;
+                return point;
+            },
+
+            handleViewportPointerMove(event) {
+                if (!this.debug || this.isInteractive()) {
+                    return;
+                }
+
+                const pageShell = getPageShellFromPoint(event);
+                if (!pageShell) {
+                    this.handlePointerLeave();
+                    return;
+                }
+
+                this.updatePointer(event, pageShell);
+            },
+
+            handlePointerMove(event, pageIndex) {
+                if (!this.debug && !this.isInteractive()) {
+                    return;
+                }
+
+                const pageShell = event.currentTarget.closest('[data-reader-page-shell]');
+                this.updatePointer(event, pageShell, pageIndex);
+            },
+
+            handlePointerLeave() {
+                this.pointerPageIndex = null;
+                this.pointerPoint = null;
+            },
+
+            handlePointerDown(event, pageIndex) {
+                if (!this.isInteractive()) {
+                    return;
+                }
+
+                const pageShell = event.currentTarget.closest('[data-reader-page-shell]');
+                const point = this.updatePointer(event, pageShell, pageIndex);
+                if (!point) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+            },
+
+            handlePointerUp(event) {
+                if (!this.isInteractive()) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+            },
+
+            getPointerLabel() {
+                if (!this.pointerPoint || !Number.isInteger(this.pointerPageIndex)) {
+                    return '';
+                }
+
+                const x = this.pointerPoint.x.toFixed(3);
+                const y = this.pointerPoint.y.toFixed(3);
+                return `Page ${this.pointerPageIndex + 1}: x ${x}, y ${y}`;
+            }
+        };
+    }
+
+    window.parker = window.parker || {};
+    window.parker.createReaderOverlayLayer = createReaderOverlayLayer;
+})();

--- a/tests/api/test_reader_overlay_shell.py
+++ b/tests/api/test_reader_overlay_shell.py
@@ -1,0 +1,10 @@
+def test_reader_page_composes_overlay_enhancement(auth_client):
+    response = auth_client.get("/reader/123")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "window.createReader({ comicId: 123 })" in body
+    assert "window.parker.applyReaderOverlayEnhancements(window.createReader({ comicId: 123 }))" in body
+    assert "/static/js/reader.js" in body
+    assert "/static/js/reader-overlays.js" in body
+    assert "/static/js/reader-annotations.js" in body


### PR DESCRIPTION
## Summary

* Add foundational reader overlay infrastructure using per-page SVG layers
* Add an overlay debug mode with page borders, center guides, page labels, and a normalized coordinate HUD
* Introduce `reader-overlays.js` for generic overlay behavior and `reader-annotations.js` as the future annotation integration point
* Compose overlay behavior explicitly around the existing `window.createReader(...)` reader shell
* Wire overlay layers into both paged and long-view reader modes
* Improve paged Fit Width behavior so oversized pages can scroll vertically while retaining edge navigation and cursor affordance
* Add a scope document for the future annotation/overlay system

## Validation

* Ran full `pytest` suite
* Manually tested overlay alignment with `?overlay_debug=true`
* Verified single-page mode
* Verified double-page mode
* Verified Fit Screen, Fit Height, and Fit Width
* Verified Fit Width vertical scrolling, left/right navigation zones, and cursor behavior
* Verified Long View overlay rendering
* Verified normalized coordinate HUD reports expected page-relative coordinates
