### PR TITLE
Add letter navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Volume-level `Following` for future issue tracking by run
   - Optional single-volume series shortcut to open the volume detail page directly
   - Paginated Details tabs for large series and volume metadata sets
+  - Alphabet jump navigation for large library detail pages
 
 - **User System**
   - Multi‑library access with row‑level security

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -34,6 +34,21 @@ logger = logging.getLogger(__name__)
 LIBRARY_NAME_REQUIRED_MESSAGE = "Library name is required"
 LIBRARY_ROOT_PATH_REQUIRED_MESSAGE = "Library root path is required"
 LIBRARY_ROOT_SCAN_ACTIVE_MESSAGE = "Library roots cannot be changed while a scan is queued or running"
+LIBRARY_SERIES_LETTERS = ["#", *list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")]
+
+
+class LibrarySeriesLetterAnchor(BaseModel):
+    letter: str
+    available: bool
+    page: Optional[int] = None
+    index: Optional[int] = None
+    count: int = 0
+
+
+class LibrarySeriesLetterResponse(BaseModel):
+    total: int
+    size: int
+    anchors: List[LibrarySeriesLetterAnchor]
 
 
 def _normalize_library_name(value: str) -> str:
@@ -48,6 +63,39 @@ def _normalize_library_root_path(value: str) -> str:
     if not normalized:
         raise ValueError(LIBRARY_ROOT_PATH_REQUIRED_MESSAGE)
     return normalized
+
+
+def _library_series_sort_key():
+    return case(
+        (Series.name.ilike("The %"), func.substr(Series.name, 5)),
+        else_=Series.name,
+    )
+
+
+def _visible_library_series_query(db, library: Library, current_user: CurrentUser):
+    query = db.query(Series).filter(Series.library_id == library.id)
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+    return query
+
+
+def _series_sort_name(name: str) -> str:
+    normalized = (name or "").strip()
+    if normalized.lower().startswith("the "):
+        return normalized[4:].lstrip()
+    return normalized
+
+
+def _series_sort_letter(name: str) -> str:
+    sort_name = _series_sort_name(name)
+    if not sort_name:
+        return "#"
+
+    first = sort_name[0].upper()
+    if "A" <= first <= "Z":
+        return first
+    return "#"
 
 
 def _find_library_by_name(
@@ -460,6 +508,45 @@ async def unpin_library(library: LibraryDep, db: SessionDep, current_user: Curre
     return {"library_id": library.id, "pinned": False}
 
 
+@router.get("/{library_id}/series/letters", response_model=LibrarySeriesLetterResponse, name="series_letters")
+async def get_library_series_letters(
+        library: LibraryDep,
+        db: SessionDep,
+        current_user: CurrentUser,
+        size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 50,
+):
+    """
+    Returns page targets for jumping to the first visible series under each
+    letter, using the same library sorting and visibility rules as series pages.
+    """
+    rows = (
+        _visible_library_series_query(db, library, current_user)
+        .with_entities(Series.name)
+        .order_by(_library_series_sort_key())
+        .all()
+    )
+
+    anchors = {
+        letter: {"letter": letter, "available": False, "page": None, "index": None, "count": 0}
+        for letter in LIBRARY_SERIES_LETTERS
+    }
+
+    for position, row in enumerate(rows):
+        letter = _series_sort_letter(row[0])
+        anchor = anchors[letter]
+        anchor["count"] += 1
+        if not anchor["available"]:
+            anchor["available"] = True
+            anchor["page"] = (position // size) + 1
+            anchor["index"] = position % size
+
+    return {
+        "total": len(rows),
+        "size": size,
+        "anchors": [anchors[letter] for letter in LIBRARY_SERIES_LETTERS],
+    }
+
+
 @router.get("/{library_id}/series", response_model=PaginatedResponse, name="series")
 async def get_library_series(
         library: LibraryDep,
@@ -474,13 +561,7 @@ async def get_library_series(
     """
 
     # 1. Filter by Library
-    query = db.query(Series).filter(Series.library_id == library.id)
-
-    # --- AGE RATING FILTER ---
-    age_filter = get_series_age_restriction(current_user)
-    if age_filter is not None:
-        query = query.filter(age_filter)
-    # -------------------------
+    query = _visible_library_series_query(db, library, current_user)
 
 
     # 2. Pagination
@@ -489,12 +570,7 @@ async def get_library_series(
     # SMART SORTING: Ignore "The " prefix
     # Logic: If name starts with "The ", use substring starting at char 5. Else use name.
     # We use .ilike for case-insensitive matching
-    sort_key = case(
-        (Series.name.ilike("The %"), func.substr(Series.name, 5)),
-        else_=Series.name
-    )
-
-    series_list = query.order_by(sort_key).offset(params.skip).limit(params.size).all()
+    series_list = query.order_by(_library_series_sort_key()).offset(params.skip).limit(params.size).all()
     if not series_list:
         return {"total": total, "page": params.page, "size": params.size, "items": []}
 

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -9,6 +9,70 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
+IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.jxl', '.avif'}
+IGNORE_FILENAMES = {'thumbs.db', '.ds_store', 'comicinfo.xml', '__macosx'}
+IGNORE_EXTENSIONS = {'.nfo', '.sfv', '.txt', '.xml', '.db', '.ini'}
+EXPLICIT_END_PAGE_RE = re.compile(r'^z+[\W_]')
+EXPLICIT_COVER_RE = re.compile(r'(?:^|[\W_])(fc|cover|front|scan)(?:$|[\W_])')
+TRAILING_PAGE_NUMBER_RE = re.compile(r'^(.*?)(?:[\s._-]+)?(\d+)\s*$')
+
+
+def _split_archive_path(filename: str) -> tuple[str, str]:
+    parts = re.split(r'([\\/])', filename)
+    if len(parts) == 1:
+        return "", filename
+
+    return "".join(parts[:-1]), parts[-1]
+
+
+def _normalize_page_sort_text(text: str) -> str:
+    return text.lower().replace('-', '~').replace('_', '~')
+
+
+def _natural_sort_parts(text: str) -> list:
+    return [int(part) if part.isdigit() else part for part in re.split(r'(\d+)', text)]
+
+
+def _priority_bucket(filename: str) -> int:
+    text = filename.lower()
+    if EXPLICIT_END_PAGE_RE.match(text):
+        return 2
+    if EXPLICIT_COVER_RE.search(text):
+        return 0
+    return 1
+
+
+def _split_trailing_page_number(stem: str) -> tuple[str, int | None]:
+    match = TRAILING_PAGE_NUMBER_RE.match(stem.strip())
+    if not match:
+        return stem.strip(), None
+
+    return match.group(1).strip(), int(match.group(2))
+
+
+def _page_sort_key(filename: str) -> tuple:
+    """
+    Sort comic archive pages while keeping likely base cover files before
+    same-stem numbered interior pages.
+    """
+    directory, basename = _split_archive_path(filename)
+    stem = Path(basename).stem
+    base_stem, trailing_number = _split_trailing_page_number(stem)
+
+    base_name = f"{directory}{base_stem}"
+    normalized_base = _normalize_page_sort_text(base_name)
+    normalized_full = _normalize_page_sort_text(filename)
+
+    has_trailing_number = trailing_number is not None
+    return (
+        _priority_bucket(filename),
+        _natural_sort_parts(normalized_base),
+        1 if has_trailing_number else 0,
+        trailing_number if trailing_number is not None else -1,
+        _natural_sort_parts(normalized_full),
+    )
+
+
 # Import the rarfile configuration
 import rarfile
 try:
@@ -70,13 +134,6 @@ class ComicArchive:
 
     def get_pages(self) -> List[str]:
         """Get sorted list of image files (pages) - filter out non-images"""
-        # Valid image extensions
-        image_extensions = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.jxl', '.avif'}
-
-        # Files to explicitly ignore (common in comic archives)
-        ignore_patterns = {'thumbs.db', '.ds_store', 'comicinfo.xml', '__macosx'}
-        ignore_extensions = {'.nfo', '.sfv', '.txt', '.xml', '.db', '.ini'}
-
         files = self.get_file_list()
 
         # Filter to valid images only
@@ -86,59 +143,18 @@ class ComicArchive:
             filename_lower = file_path.name.lower()
 
             # Skip ignored files
-            if filename_lower in ignore_patterns:
+            if filename_lower in IGNORE_FILENAMES:
                 continue
 
             # Skip ignored extensions
-            if file_path.suffix.lower() in ignore_extensions:
+            if file_path.suffix.lower() in IGNORE_EXTENSIONS:
                 continue
 
             # Only include valid image files
-            if file_path.suffix.lower() in image_extensions:
+            if file_path.suffix.lower() in IMAGE_EXTENSIONS:
                 pages.append(f)
 
-        # --- IMPROVED SORTING LOGIC ---
-        def sort_key(filename):
-            """
-            Multi-stage sort key:
-            1. Priority: Explicit covers ('fc', 'cover') come first (0), end-pages ('z-') come last (2).
-            2. Natural: Numbers sorted numerically (1, 2, 10).
-            3. Symbols: Separators de-prioritized so 'c01a' < 'c01-'.
-            """
-            # 1. Normalize case
-            text = filename.lower()
-
-            # 2. PRIORITY BUCKETING
-            # Check for explicit end-of-archive naming conventions like 'z.', 'z-', 'zz_'
-            if re.match(r'^z+[\W_]', text):
-                priority = 2
-            # Check for explicit cover naming conventions using regex word boundaries.
-            # Regex updated to handle:
-            # - Underscore prefixes (e.g. "_cover") which \b misses because _ is a word char
-            # - "scan" keyword (e.g. "scan.jpg" vs "scan01.jpg")
-            # This ensures "scan01" doesn't trigger it (0 is a word char), but "scan.jpg" does.
-            # Pattern: (Start/NonWord/_) + Keyword + (End/NonWord/_)
-            # matches " fc ", "fc.", "-fc", etc.
-            # 0 = Cover (Highest), 1 = Standard, 2 = End Page (Lowest)
-            elif re.search(r'(?:^|[\W_])(fc|cover|front|scan)(?:$|[\W_])', text):
-                priority = 0
-            else:
-                priority = 1
-
-            # 3. SEPARATOR HACK (From previous fix)
-            # Replace separators with high-ASCII char '~' to ensure letters sort before symbols.
-            # 'c01a' (a=97) < 'c01-' (~=126)
-            text = text.replace('-', '~').replace('_', '~')
-
-            # 4. NATURAL SORT SPLIT
-            # Split into [text, number, text, number...]
-            natural_parts = [int(c) if c.isdigit() else c for c in re.split(r'(\d+)', text)]
-
-            # Return tuple: (Priority, Natural_Sort_Parts)
-            return (priority, natural_parts)
-
-        # ------------------------------
-        pages.sort(key=sort_key)
+        pages.sort(key=_page_sort_key)
 
         return pages
 

--- a/app/templates/comics/series_detail.html
+++ b/app/templates/comics/series_detail.html
@@ -943,7 +943,7 @@ function seriesDetail() {
             const confirmed = await window.parker.dialog.confirm(
                 "Regenerate Thumbnails?",
                 "Regenerate all thumbnails for this series? This may take a moment.",
-                { isDestructive: true, confirmText: 'Remove' }
+                { isDestructive: true, confirmText: 'Regenerate' }
             );
 
             if(!confirmed) return;

--- a/app/templates/libraries/library.html
+++ b/app/templates/libraries/library.html
@@ -9,12 +9,12 @@
         <div class="flex items-center space-x-4" x-show="!error" x-cloak>
             <a :href="window.parker.route('pages.libraries')" class="text-blue-400 hover:text-blue-300">← Back</a>
 
-            <div x-show="loading.meta" class="h-8 w-48 bg-gray-700 rounded animate-pulse"></div>
+            <div x-show="metaLoading" class="h-8 w-48 bg-gray-700 rounded animate-pulse"></div>
 
-            <h1 x-show="!loading.meta" class="text-3xl font-bold text-white" x-text="library?.name"></h1>
+            <h1 x-show="!metaLoading" class="text-3xl font-bold text-white" x-text="library?.name"></h1>
         </div>
 
-        <div x-show="!loading.meta && library">
+        <div x-show="!metaLoading && library">
             <button
                 type="button"
                 x-on:click="toggleLibraryPin()"
@@ -42,6 +42,32 @@
         </div>
     </div>
 
+    <div
+        x-show="showLetterNavigation()"
+        x-cloak
+        class="border-y border-gray-800 py-3"
+        role="navigation"
+        aria-label="Series letter navigation"
+    >
+        <div class="flex items-center gap-3 overflow-x-auto">
+            <span class="flex-shrink-0 text-xs font-semibold uppercase text-gray-500">Jump</span>
+            <div class="flex min-w-max items-center gap-1">
+                <template x-for="anchor in letterAnchors" :key="anchor.letter">
+                    <button
+                        type="button"
+                        x-on:click="jumpToLetter(anchor)"
+                        :disabled="!anchor.available || loading"
+                        :aria-label="anchor.available ? `Jump to ${anchor.letter}` : `${anchor.letter} unavailable`"
+                        :aria-current="activeLetter === anchor.letter ? 'true' : null"
+                        class="h-8 w-8 flex-shrink-0 rounded border text-xs font-bold transition-colors"
+                        :class="letterButtonClass(anchor)"
+                        x-text="anchor.letter"
+                    ></button>
+                </template>
+            </div>
+        </div>
+    </div>
+
 
     <div class="min-h-[500px]">
         <div x-show="loading && items.length === 0" class="flex justify-center py-20">
@@ -50,7 +76,7 @@
 
         <div x-show="items.length > 0">
 
-            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
+            <div x-ref="seriesGrid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
                 <template x-for="series in items" :key="series.id">
                     {% include "partials/series_card.html" %}
                 </template>
@@ -109,20 +135,33 @@ function libraryView() {
         libraryId: {{ library_id }},
         library: null,
         error: null,
+        metaLoading: true,
+        letterAnchors: [],
+        letterTotal: 0,
+        lettersLoading: true,
+        activeLetter: null,
+        pendingLetterIndex: null,
 
-        loading: {
-            meta: true
-        },
         ...window.parker.paginationMixin(
             'libraries.series',
             function() { return { library_id: this.libraryId }; },
             {
                 pageSize: 50,
-                mode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}'
+                mode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
+                onLoaded: function(data, append) {
+                    if (!append && this.pendingLetterIndex === null) {
+                        this.activeLetter = null;
+                    }
+
+                    if (!append) {
+                        this.scrollToPendingLetter();
+                    }
+                }
             }
         ),
         init() {
             this.loadLibraryMeta();
+            this.loadLetterAnchors();
             this.loadItems();
         },
 
@@ -145,8 +184,74 @@ function libraryView() {
             } catch (e) {
                 console.error(e);
             } finally {
-                this.loading.meta = false;
+                this.metaLoading = false;
             }
+        },
+
+        async loadLetterAnchors() {
+            this.lettersLoading = true;
+
+            try {
+                const query = new URLSearchParams({ size: String(this.size) });
+                const res = await fetch(
+                    window.parker.route('libraries.series_letters', { library_id: this.libraryId }, query.toString())
+                );
+
+                if (!res.ok) {
+                    throw new Error('Failed to load letter navigation');
+                }
+
+                const data = await res.json();
+                this.letterAnchors = data.anchors || [];
+                this.letterTotal = data.total || 0;
+            } catch (e) {
+                console.error(e);
+                this.letterAnchors = [];
+                this.letterTotal = 0;
+            } finally {
+                this.lettersLoading = false;
+            }
+        },
+
+        showLetterNavigation() {
+            return !this.lettersLoading
+                && this.letterTotal > this.size
+                && this.letterAnchors.some(anchor => anchor.available);
+        },
+
+        letterButtonClass(anchor) {
+            if (!anchor.available) {
+                return 'border-gray-800 bg-gray-900 text-gray-700 cursor-not-allowed';
+            }
+
+            if (this.activeLetter === anchor.letter) {
+                return 'border-blue-400 bg-blue-600 text-white';
+            }
+
+            return 'border-gray-700 bg-gray-800 text-gray-300 hover:border-blue-400 hover:text-white';
+        },
+
+        async jumpToLetter(anchor) {
+            if (!anchor.available || !anchor.page || this.loading) return;
+
+            this.activeLetter = anchor.letter;
+            this.pendingLetterIndex = Number.isInteger(anchor.index) ? anchor.index : 0;
+            this.page = anchor.page;
+            await this.loadItems(false);
+        },
+
+        scrollToPendingLetter() {
+            if (this.pendingLetterIndex === null) return;
+
+            const targetIndex = this.pendingLetterIndex;
+            this.pendingLetterIndex = null;
+
+            this.$nextTick(() => {
+                const target = this.$refs.seriesGrid?.children?.[targetIndex];
+                if (target) {
+                    target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+                }
+            });
         },
 
         async toggleLibraryPin() {

--- a/app/templates/libraries/library.html
+++ b/app/templates/libraries/library.html
@@ -141,6 +141,8 @@ function libraryView() {
         lettersLoading: true,
         activeLetter: null,
         pendingLetterIndex: null,
+        loadedStartPage: null,
+        loadedEndPage: null,
 
         ...window.parker.paginationMixin(
             'libraries.series',
@@ -149,6 +151,15 @@ function libraryView() {
                 pageSize: 50,
                 mode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
                 onLoaded: function(data, append) {
+                    const loadedPage = Number.isInteger(data.page) ? data.page : this.page;
+                    if (append) {
+                        this.loadedStartPage = this.loadedStartPage || loadedPage;
+                        this.loadedEndPage = Math.max(this.loadedEndPage || loadedPage, loadedPage);
+                    } else {
+                        this.loadedStartPage = loadedPage;
+                        this.loadedEndPage = loadedPage;
+                    }
+
                     if (!append && this.pendingLetterIndex === null) {
                         this.activeLetter = null;
                     }
@@ -235,9 +246,38 @@ function libraryView() {
             if (!anchor.available || !anchor.page || this.loading) return;
 
             this.activeLetter = anchor.letter;
+            const targetIndex = Number.isInteger(anchor.index) ? anchor.index : 0;
+
+            if (this.isLetterPageLoaded(anchor.page)) {
+                this.scrollToSeriesIndex(this.localLetterIndex(anchor.page, targetIndex));
+                return;
+            }
+
             this.pendingLetterIndex = Number.isInteger(anchor.index) ? anchor.index : 0;
             this.page = anchor.page;
             await this.loadItems(false);
+        },
+
+        isLetterPageLoaded(page) {
+            return this.mode === 'infinite'
+                && Number.isInteger(page)
+                && Number.isInteger(this.loadedStartPage)
+                && Number.isInteger(this.loadedEndPage)
+                && page >= this.loadedStartPage
+                && page <= this.loadedEndPage;
+        },
+
+        localLetterIndex(page, index) {
+            return ((page - this.loadedStartPage) * this.size) + index;
+        },
+
+        scrollToSeriesIndex(index) {
+            this.$nextTick(() => {
+                const target = this.$refs.seriesGrid?.children?.[index];
+                if (target) {
+                    target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+                }
+            });
         },
 
         scrollToPendingLetter() {
@@ -246,12 +286,7 @@ function libraryView() {
             const targetIndex = this.pendingLetterIndex;
             this.pendingLetterIndex = null;
 
-            this.$nextTick(() => {
-                const target = this.$refs.seriesGrid?.children?.[targetIndex];
-                if (target) {
-                    target.scrollIntoView({ block: 'start', behavior: 'smooth' });
-                }
-            });
+            this.scrollToSeriesIndex(targetIndex);
         },
 
         async toggleLibraryPin() {

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -18,9 +18,11 @@ Status: Draft
 ## Fixed
 
 - Fixed anchored Cover Browser deep links loading every earlier manifest page from offset `0` before reaching covers later in large series or volume contexts.
+- Fixed archive page sorting so likely base cover images such as `dc_gods.jpg` and `Lord of the Ultra-Realms 01 .jpg` are chosen before same-stem numbered interior pages.
 - Fixed library detail metadata loading state so header placeholders and pin controls use their own loading flag instead of the series pagination flag.
 
 ## Validation
 
 - Verified anchored Cover Browser manifest positioning and browser deep-link behavior: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_comics.py::test_cover_manifest_anchor_comic_id_starts_near_requested_item tests\browser\test_navigation_smoke.py::test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages -q`.
+- Verified archive page filtering, explicit cover/end-page priority, separator ordering, and same-stem base-cover precedence for numbered interior pages: `6 passed` via `.\.venv\Scripts\python.exe -m pytest tests\services\test_archive.py -q`.
 - Verified library alphabet jump anchor page/index calculation, age-restricted visibility, replace-window behavior, forward infinite-scroll continuation, and in-place scrolling when the target page is already loaded: `4 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward tests\browser\test_navigation_smoke.py::test_library_letter_jump_scrolls_without_reload_when_page_is_loaded -q`.

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -20,6 +20,7 @@ Status: Draft
 - Fixed anchored Cover Browser deep links loading every earlier manifest page from offset `0` before reaching covers later in large series or volume contexts.
 - Fixed archive page sorting so likely base cover images such as `dc_gods.jpg` and `Lord of the Ultra-Realms 01 .jpg` are chosen before same-stem numbered interior pages.
 - Fixed library detail metadata loading state so header placeholders and pin controls use their own loading flag instead of the series pagination flag.
+- Fixed Regenerate Thumbnail modal's confirmation button from 'Remove' to 'Regenerate' to better reflect the action that will take place.
 
 ## Validation
 

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -12,6 +12,7 @@ Status: Draft
 ## Changed
 
 - Cover Browser manifest loading now tracks the loaded window's base offset and can lazy-load previous pages as well as next pages, keeping position labels and navigation accurate when a deep link starts in the middle of a run.
+- Library alphabet jumps in infinite-scroll mode now scroll directly to a letter when that letter's page is already loaded, avoiding an unnecessary page reload.
 - README documentation now describes Parallel Thumbnail Generation `Auto` mode as using 50% of available CPU cores.
 
 ## Fixed
@@ -22,5 +23,4 @@ Status: Draft
 ## Validation
 
 - Verified anchored Cover Browser manifest positioning and browser deep-link behavior: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_comics.py::test_cover_manifest_anchor_comic_id_starts_near_requested_item tests\browser\test_navigation_smoke.py::test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages -q`.
-- Verified library alphabet jump anchor page/index calculation and age-restricted visibility: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction -q`.
-- Verified library alphabet jumps replace the current infinite-scroll window and continue loading forward from the selected letter: `1 passed` via `.\.venv\Scripts\python.exe -m pytest tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward -q`.
+- Verified library alphabet jump anchor page/index calculation, age-restricted visibility, replace-window behavior, forward infinite-scroll continuation, and in-place scrolling when the target page is already loaded: `4 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward tests\browser\test_navigation_smoke.py::test_library_letter_jump_scrolls_without_reload_when_page_is_loaded -q`.

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -2,11 +2,12 @@
 
 Status: Draft
 
-`0.1.33` starts with a Cover Browser anchored deep-link fix for large runs and a documentation clarification for parallel thumbnail CPU configuration.
+`0.1.33` starts with a Cover Browser anchored deep-link fix for large runs, library alphabet jump navigation, and a documentation clarification for parallel thumbnail CPU configuration.
 
 ## Added
 
 - Added `anchor_comic_id` support to the cover manifest API so comic-detail cover jumps can request the manifest window around the target issue directly.
+- Added alphabet jump navigation to library detail pages so large paginated libraries can jump directly to the page containing a selected starting letter.
 
 ## Changed
 
@@ -16,7 +17,10 @@ Status: Draft
 ## Fixed
 
 - Fixed anchored Cover Browser deep links loading every earlier manifest page from offset `0` before reaching covers later in large series or volume contexts.
+- Fixed library detail metadata loading state so header placeholders and pin controls use their own loading flag instead of the series pagination flag.
 
 ## Validation
 
 - Verified anchored Cover Browser manifest positioning and browser deep-link behavior: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_comics.py::test_cover_manifest_anchor_comic_id_starts_near_requested_item tests\browser\test_navigation_smoke.py::test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages -q`.
+- Verified library alphabet jump anchor page/index calculation and age-restricted visibility: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction -q`.
+- Verified library alphabet jumps replace the current infinite-scroll window and continue loading forward from the selected letter: `1 passed` via `.\.venv\Scripts\python.exe -m pytest tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward -q`.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -660,6 +660,9 @@ document.addEventListener('error', function(e) {
                         }
                     }
                     this.total = data.total;
+                    if (config.onLoaded) {
+                        config.onLoaded.call(this, data, append);
+                    }
 
                 } catch (e) {
                     console.error("Pagination Error:", e);

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -411,6 +411,35 @@ def test_get_library_series_empty_page_returns_empty_items(auth_client, db, norm
     assert response.json() == {"total": 0, "page": 1, "size": 5, "items": []}
 
 
+def test_get_library_series_letter_anchors_use_library_sort_pages(auth_client, db, normal_user):
+    library = create_library_with_root(db, "Letter Anchor Library", "/tmp/letter-anchor-library")
+    db.add_all([
+        Series(name="123 Go", library=library),
+        Series(name="The Alpha", library=library),
+        Series(name="Beta", library=library),
+        Series(name="X-Force", library=library),
+        Series(name="X-Men", library=library),
+        Series(name="Zatanna", library=library),
+    ])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/libraries/{library.id}/series/letters?size=2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    anchors = {anchor["letter"]: anchor for anchor in payload["anchors"]}
+
+    assert payload["total"] == 6
+    assert payload["size"] == 2
+    assert anchors["#"] == {"letter": "#", "available": True, "page": 1, "index": 0, "count": 1}
+    assert anchors["A"] == {"letter": "A", "available": True, "page": 1, "index": 1, "count": 1}
+    assert anchors["B"] == {"letter": "B", "available": True, "page": 2, "index": 0, "count": 1}
+    assert anchors["X"] == {"letter": "X", "available": True, "page": 2, "index": 1, "count": 2}
+    assert anchors["Z"] == {"letter": "Z", "available": True, "page": 3, "index": 1, "count": 1}
+    assert anchors["C"] == {"letter": "C", "available": False, "page": None, "index": None, "count": 0}
+
+
 def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
     library = create_library_with_root(
         db,
@@ -1411,6 +1440,16 @@ def test_get_library_series_filters_by_age_restriction(auth_client, db, normal_u
     assert payload["total"] == 1
     assert len(payload["items"]) == 1
     assert payload["items"][0]["id"] == safe_series.id
+
+    letters_response = auth_client.get(f"/api/libraries/{library.id}/series/letters?size=10")
+
+    assert letters_response.status_code == 200
+    letters_payload = letters_response.json()
+    anchors = {anchor["letter"]: anchor for anchor in letters_payload["anchors"]}
+    assert letters_payload["total"] == 1
+    assert anchors["S"]["available"] is True
+    assert anchors["S"]["count"] == 1
+    assert anchors["B"]["available"] is False
 
 
 def test_get_library_series_cover_fallback_handles_non_numeric_numbers(auth_client, db, normal_user):

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -250,6 +250,8 @@ def browser_server(browser_db_factory, browser_seed_data, monkeypatch_session):
         # browser server isolated from whatever the local app database contains.
         if key == "ui.auto_redirect_single_volume_series":
             return False
+        if key == "ui.pagination_mode":
+            return "infinite"
         return original_get_cached_setting(key, default)
 
     monkeypatch_session.setattr(pages_router, "get_cached_setting", browser_get_cached_setting)

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -147,6 +147,26 @@ def _remove_library_letter_jump_fixture(browser_server, series_ids):
         session.close()
 
 
+def _add_loaded_letter_jump_fixture(browser_server):
+    session = browser_server["db_factory"]()
+    try:
+        volume = session.get(Volume, browser_server["seed"]["volume_id"])
+        library = volume.series.library
+        series_rows = [
+            *[Series(name=f"Alpha Loaded {index:02d}", library=library) for index in range(49)],
+            Series(name="S Jump Target", library=library),
+            Series(name="Z Loaded Tail", library=library),
+        ]
+        session.add_all(series_rows)
+        session.flush()
+        library_id = library.id
+        series_ids = [series.id for series in series_rows]
+        session.commit()
+        return library_id, series_ids
+    finally:
+        session.close()
+
+
 @pytest.mark.browser
 def test_continue_reading_page_shows_in_progress_items_and_opens_reader(page, browser_server):
     seed = browser_server["seed"]
@@ -343,6 +363,40 @@ def test_library_letter_jump_replaces_infinite_window_and_continues_forward(page
             }
             """
         )
+    finally:
+        _remove_library_letter_jump_fixture(browser_server, series_ids)
+
+
+@pytest.mark.browser
+def test_library_letter_jump_scrolls_without_reload_when_page_is_loaded(page, browser_server):
+    library_id, series_ids = _add_loaded_letter_jump_fixture(browser_server)
+    request_urls = []
+
+    try:
+        page.goto(f"{browser_server['base_url']}/libraries/{library_id}", wait_until="networkidle")
+        page.get_by_role("button", name="Jump to S").wait_for()
+        page.on("request", lambda request: request_urls.append(request.url))
+
+        page.get_by_role("button", name="Jump to S").click()
+
+        page.get_by_text("S Jump Target").wait_for()
+        page.wait_for_function(
+            """
+            () => {
+                const state = document.querySelector('[x-data="libraryView()"]')?._x_dataStack?.[0];
+                return state?.activeLetter === 'S'
+                    && state?.loadedStartPage === 1
+                    && window.scrollY > 0;
+            }
+            """
+        )
+        page.wait_for_timeout(300)
+
+        series_requests = [
+            url for url in request_urls
+            if f"/api/libraries/{library_id}/series?" in url
+        ]
+        assert not any("page=1" in url for url in series_requests)
     finally:
         _remove_library_letter_jump_fixture(browser_server, series_ids)
 

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
+from app.models.series import Series
 from app.models.tags import Character
 from tests.factories import create_comic
 
@@ -111,6 +112,36 @@ def _remove_large_cover_browser_fixture(browser_server, comic_ids):
     try:
         if comic_ids:
             session.query(Comic).filter(Comic.id.in_(comic_ids)).delete(synchronize_session=False)
+            session.commit()
+    finally:
+        session.close()
+
+
+def _add_library_letter_jump_fixture(browser_server):
+    session = browser_server["db_factory"]()
+    try:
+        volume = session.get(Volume, browser_server["seed"]["volume_id"])
+        library = volume.series.library
+        series_rows = [
+            *[Series(name=f"Alpha Jump {index:02d}", library=library) for index in range(60)],
+            *[Series(name=f"X Jump Target {index:02d}", library=library) for index in range(3)],
+            *[Series(name=f"Z Jump Tail {index:02d}", library=library) for index in range(55)],
+        ]
+        session.add_all(series_rows)
+        session.flush()
+        library_id = library.id
+        series_ids = [series.id for series in series_rows]
+        session.commit()
+        return library_id, series_ids
+    finally:
+        session.close()
+
+
+def _remove_library_letter_jump_fixture(browser_server, series_ids):
+    session = browser_server["db_factory"]()
+    try:
+        if series_ids:
+            session.query(Series).filter(Series.id.in_(series_ids)).delete(synchronize_session=False)
             session.commit()
     finally:
         session.close()
@@ -274,6 +305,46 @@ def test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages(pa
         )
     finally:
         _remove_large_cover_browser_fixture(browser_server, comic_ids)
+
+
+@pytest.mark.browser
+def test_library_letter_jump_replaces_infinite_window_and_continues_forward(page, browser_server):
+    library_id, series_ids = _add_library_letter_jump_fixture(browser_server)
+
+    try:
+        page.goto(f"{browser_server['base_url']}/libraries/{library_id}", wait_until="networkidle")
+        page.get_by_role("heading", name="Browser Test Library").wait_for()
+
+        page.get_by_role("button", name="Jump to X").click()
+        page.wait_for_function(
+            """
+            () => {
+                const state = document.querySelector('[x-data="libraryView()"]')?._x_dataStack?.[0];
+                const names = state?.items?.map((item) => item.name) || [];
+                return state?.mode === 'infinite'
+                    && state?.page === 2
+                    && names.includes('X Jump Target 00')
+                    && !names.includes('Alpha Jump 00');
+            }
+            """
+        )
+
+        target = page.get_by_text("X Jump Target 00")
+        target.wait_for()
+        assert target.is_visible()
+
+        page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        page.wait_for_function(
+            """
+            () => {
+                const state = document.querySelector('[x-data="libraryView()"]')?._x_dataStack?.[0];
+                const names = state?.items?.map((item) => item.name) || [];
+                return state?.page === 3 && names.includes('Z Jump Tail 54');
+            }
+            """
+        )
+    finally:
+        _remove_library_letter_jump_fixture(browser_server, series_ids)
 
 
 @pytest.mark.browser

--- a/tests/services/test_archive.py
+++ b/tests/services/test_archive.py
@@ -108,3 +108,43 @@ def test_comic_archive_sort_pages_complex_names():
         ]
         
         assert pages == expected
+
+
+def test_comic_archive_sort_pages_prefers_issue_base_image_before_numbered_page():
+    with patch("app.services.archive.zipfile.is_zipfile", return_value=True), \
+         patch("app.services.archive.zipfile.ZipFile"):
+        archive = ComicArchive(Path("dummy.cbz"))
+
+        archive.get_file_list = MagicMock(return_value=[
+            " Lord of the Ultra-Realms 01 0001.jpg",
+            " Lord of the Ultra-Realms 01 0002.jpg",
+            " Lord of the Ultra-Realms 01 .jpg",
+        ])
+
+        pages = archive.get_pages()
+
+        assert pages == [
+            " Lord of the Ultra-Realms 01 .jpg",
+            " Lord of the Ultra-Realms 01 0001.jpg",
+            " Lord of the Ultra-Realms 01 0002.jpg",
+        ]
+
+
+def test_comic_archive_sort_pages_prefers_same_stem_cover_before_appended_page_number():
+    with patch("app.services.archive.zipfile.is_zipfile", return_value=True), \
+         patch("app.services.archive.zipfile.ZipFile"):
+        archive = ComicArchive(Path("dummy.cbz"))
+
+        archive.get_file_list = MagicMock(return_value=[
+            "dc_gods02.jpg",
+            "dc_gods01.jpg",
+            "dc_gods.jpg",
+        ])
+
+        pages = archive.get_pages()
+
+        assert pages == [
+            "dc_gods.jpg",
+            "dc_gods01.jpg",
+            "dc_gods02.jpg",
+        ]


### PR DESCRIPTION

## Summary

Adds first-pass alphabet jump navigation to library detail pages for large libraries, and tightens archive page sorting for cover detection edge cases.

### What Changed

- Added an alphabet jump bar to library detail pages when the visible series count exceeds one page.
- Added a `/api/libraries/{library_id}/series/letters` endpoint that shares the same library filtering, age restriction filtering, and `The `-aware sorting as the normal series list.
- Supports both pagination modes:
  - classic pagination jumps to the target page
  - infinite scroll replaces the loaded window when needed, but scrolls in-place when the target letter’s page is already loaded
- Refactored archive page sorting into named helpers to reduce the “spaghetti” risk around cover detection.
- Fixed cover selection for same-stem numbered page cases, including:
  - `Lord of the Ultra-Realms 01 .jpg` before `Lord of the Ultra-Realms 01 0001.jpg`
  - `dc_gods.jpg` before `dc_gods01.jpg`
- Updated README and `0.1.33` release notes.
- Changed the series thumbnail regeneration confirmation button text from `Remove` to `Regenerate`.

## Notes

The alphabet jump behavior is intentionally still forward-only for infinite scroll. If the target page has not already been loaded, Parker loads that page as the new window and continues forward from there. Bidirectional infinite scroll/backfill can be revisited later.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward tests\browser\test_navigation_smoke.py::test_library_letter_jump_scrolls_without_reload_when_page_is_loaded -q`
  - `4 passed`
- `.\.venv\Scripts\python.exe -m pytest tests\services\test_archive.py -q`
  - `6 passed`

