### PR TITLE
Added dedicated person detail pages for creator credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Pinned library rails for recently updated series from favorite libraries
   - Per-user Home rail customization for reordering or hiding discovery rails
   - Library Timeline for character and team histories generated from embedded metadata
+  - Dedicated person pages for creators with role-specific series rails and search handoffs
   - Recommendations by creator or metadata
   - Random gems, recently added/updated series with recency-aware volume covers
 

--- a/app/api/people.py
+++ b/app/api/people.py
@@ -1,0 +1,216 @@
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import and_, func
+
+from app.api.deps import CurrentUser, SessionDep
+from app.core.comic_helpers import get_series_age_restriction, get_smart_cover, get_thumbnail_url
+from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
+from app.models.reading_progress import ReadingProgress
+from app.models.series import Series
+
+router = APIRouter()
+
+
+PERSON_ROLE_ORDER = (
+    "writer",
+    "penciller",
+    "inker",
+    "colorist",
+    "letterer",
+    "cover_artist",
+    "editor",
+)
+
+
+def _role_label(role: str) -> str:
+    return role.replace("_", " ").title()
+
+
+def _role_sort_key(role: str) -> tuple[int, str]:
+    try:
+        return PERSON_ROLE_ORDER.index(role), role
+    except ValueError:
+        return len(PERSON_ROLE_ORDER), role
+
+
+def _apply_visible_series_scope(query, current_user: CurrentUser):
+    if not current_user.is_superuser:
+        allowed_ids = [library.id for library in current_user.accessible_libraries]
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    return query
+
+
+def _person_credit_query(db: SessionDep, person_id: int):
+    return (
+        db.query(ComicCredit)
+        .select_from(ComicCredit)
+        .join(Comic, Comic.id == ComicCredit.comic_id)
+        .join(Volume, Volume.id == Comic.volume_id)
+        .join(Series, Series.id == Volume.series_id)
+        .filter(ComicCredit.person_id == person_id)
+    )
+
+
+def _person_role_comics_query(db: SessionDep, person_id: int, role: str, current_user: CurrentUser):
+    query = (
+        db.query(Comic)
+        .join(Volume, Volume.id == Comic.volume_id)
+        .join(Series, Series.id == Volume.series_id)
+        .join(ComicCredit, ComicCredit.comic_id == Comic.id)
+        .filter(
+            ComicCredit.person_id == person_id,
+            ComicCredit.role == role,
+        )
+    )
+    return _apply_visible_series_scope(query, current_user)
+
+
+def _get_role_series(db: SessionDep, person_id: int, role: str, current_user: CurrentUser, limit: int) -> list[dict]:
+    issue_count = func.count(func.distinct(Comic.id)).label("issue_count")
+    read_count = func.count(func.distinct(ReadingProgress.id)).label("read_count")
+
+    query = (
+        db.query(
+            Series.id.label("id"),
+            Series.name.label("name"),
+            issue_count,
+            read_count,
+            func.min(Comic.year).label("start_year"),
+            func.max(Comic.year).label("end_year"),
+            func.max(Comic.publisher).label("publisher"),
+        )
+        .select_from(Series)
+        .join(Volume, Volume.series_id == Series.id)
+        .join(Comic, Comic.volume_id == Volume.id)
+        .join(ComicCredit, ComicCredit.comic_id == Comic.id)
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+                ReadingProgress.completed == True,
+            ),
+        )
+        .filter(
+            ComicCredit.person_id == person_id,
+            ComicCredit.role == role,
+        )
+    )
+    query = _apply_visible_series_scope(query, current_user)
+    rows = (
+        query
+        .group_by(Series.id, Series.name)
+        .order_by(issue_count.desc(), Series.name.asc())
+        .limit(limit)
+        .all()
+    )
+
+    items = []
+    for row in rows:
+        cover_query = _person_role_comics_query(db, person_id, role, current_user).filter(Series.id == row.id)
+        cover = get_smart_cover(cover_query, series_name=row.name)
+        issue_total = int(row.issue_count or 0)
+        read_total = int(row.read_count or 0)
+        items.append(
+            {
+                "id": row.id,
+                "name": row.name,
+                "issue_count": issue_total,
+                "start_year": row.start_year,
+                "end_year": row.end_year,
+                "publisher": row.publisher,
+                "thumbnail_path": get_thumbnail_url(cover.id, cover.updated_at) if cover else None,
+                "read": issue_total > 0 and read_total >= issue_total,
+            }
+        )
+
+    return items
+
+
+@router.get("/{person_id}", name="detail")
+async def get_person_detail(
+    person_id: int,
+    db: SessionDep,
+    current_user: CurrentUser,
+    role_limit: Annotated[int, Query(ge=1, le=24)] = 12,
+):
+    person = db.get(Person, person_id)
+    if person is None:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+    visible_credit_query = _apply_visible_series_scope(_person_credit_query(db, person_id), current_user)
+
+    total_stats = (
+        visible_credit_query
+        .with_entities(
+            func.count(func.distinct(Comic.id)).label("issue_count"),
+            func.count(func.distinct(Series.id)).label("series_count"),
+            func.min(Comic.year).label("start_year"),
+            func.max(Comic.year).label("end_year"),
+        )
+        .first()
+    )
+
+    total_issues = int(total_stats.issue_count or 0)
+    if total_issues <= 0:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+    role_issue_count = func.count(func.distinct(Comic.id)).label("issue_count")
+    role_rows = (
+        visible_credit_query
+        .with_entities(
+            ComicCredit.role.label("role"),
+            role_issue_count,
+            func.count(func.distinct(Series.id)).label("series_count"),
+            func.min(Comic.year).label("start_year"),
+            func.max(Comic.year).label("end_year"),
+        )
+        .group_by(ComicCredit.role)
+        .all()
+    )
+
+    publisher_issue_count = func.count(func.distinct(Comic.id)).label("issue_count")
+    publisher_rows = (
+        visible_credit_query
+        .with_entities(Comic.publisher.label("name"), publisher_issue_count)
+        .filter(Comic.publisher != None, Comic.publisher != "")
+        .group_by(Comic.publisher)
+        .order_by(publisher_issue_count.desc(), Comic.publisher.asc())
+        .limit(5)
+        .all()
+    )
+
+    roles = []
+    for row in sorted(role_rows, key=lambda role_row: _role_sort_key(role_row.role)):
+        roles.append(
+            {
+                "role": row.role,
+                "label": _role_label(row.role),
+                "issue_count": int(row.issue_count or 0),
+                "series_count": int(row.series_count or 0),
+                "start_year": row.start_year,
+                "end_year": row.end_year,
+                "series": _get_role_series(db, person_id, row.role, current_user, role_limit),
+            }
+        )
+
+    return {
+        "id": person.id,
+        "name": person.name,
+        "total_issues": total_issues,
+        "total_series": int(total_stats.series_count or 0),
+        "start_year": total_stats.start_year,
+        "end_year": total_stats.end_year,
+        "roles": roles,
+        "top_publishers": [
+            {"name": row.name, "issue_count": int(row.issue_count or 0)}
+            for row in publisher_rows
+        ],
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.api import batch
 from app.api import home
 from app.api import insights
 from app.api import timelines
+from app.api import people
 
 # Frontend Routes (HTML)
 from app.routers import pages, admin
@@ -238,6 +239,7 @@ app.include_router(libraries.router, prefix="/api/libraries", tags=["libraries"]
 app.include_router(series.router, prefix="/api/series", tags=["series"])
 app.include_router(volumes.router, prefix="/api/volumes", tags=["volumes"])
 app.include_router(comics.router, prefix="/api/comics", tags=["comics"])
+app.include_router(people.router, prefix="/api/people", tags=["people"])
 app.include_router(reader.router, prefix="/api/reader", tags=["reader"])
 app.include_router(bookmarks.router, prefix="/api/bookmarks", tags=["bookmarks"])
 app.include_router(reading_lists.router, prefix="/api/reading-lists", tags=["reading-lists"])

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -69,6 +69,15 @@ async def search(request: Request, user: CurrentUser):
     """Search page"""
     return templates.TemplateResponse(request=request, name="search.html")
 
+
+@router.get("/people/{person_id}", response_class=HTMLResponse, name="person_detail")
+async def person_detail(request: Request, person_id: int, user: CurrentUser):
+    """Person detail page"""
+    return templates.TemplateResponse(request=request, name="people/detail.html", context={
+        "person_id": person_id
+    })
+
+
 @router.get("/insights", response_class=HTMLResponse, name="insights")
 async def insights(request: Request, user: CurrentUser):
     """Insights landing page"""

--- a/app/templates/partials/tag_chip.html
+++ b/app/templates/partials/tag_chip.html
@@ -5,7 +5,7 @@
     - item: string (The name of the AlpineJS loop variable, e.g. 'name' or 'char')
 #}
 
-{% if type in ['writer', 'penciller', 'inker', 'colorist', 'editor'] %}
+{% if type in ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor'] %}
     {# Creators: Gray, slightly rounded #}
     {% set classes = "bg-gray-700 hover:bg-blue-600 hover:text-white text-gray-200 border border-transparent rounded" %}
 {% elif type == 'character' %}
@@ -26,7 +26,7 @@
     {% if type in ['character', 'team'] %}
     :href="window.parker.route('pages.timelines', {}, `type={{ type }}&name=${encodeURIComponent({{ item }})}`)"
     {% else %}
-    :href="window.parker.route('pages.search', {}, `field={{ type }}&value=${encodeURIComponent({{ item }})}&operator=contains`)"
+    :href="window.parker.route('pages.search', {}, `field={{ type }}&value=${encodeURIComponent({{ item }})}&operator={{ 'equal' if type in ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor'] else 'contains' }}`)"
     {% endif %}
     class="{{ classes }} px-3 py-1.5 text-sm transition-colors cursor-pointer select-none flex-shrink-0"
     x-text="{{ item }}"

--- a/app/templates/people/detail.html
+++ b/app/templates/people/detail.html
@@ -1,0 +1,259 @@
+{% extends "base.html" %}
+
+{% block title %}Person - Parker{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto" x-data="personDetail()" x-cloak>
+    <div x-show="loading" class="flex justify-center py-20">
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+    </div>
+
+    <div x-show="notFound" style="display: none;" class="max-w-lg mx-auto mt-20 text-center">
+        <div class="bg-gray-800 rounded-lg p-8 border border-gray-700 shadow-2xl">
+            <div class="text-5xl mb-4">?</div>
+            <h2 class="text-2xl font-bold text-white mb-2">Person Not Found</h2>
+            <p class="text-gray-400 mb-6">This person is not available in your visible library.</p>
+            <div class="flex gap-4 justify-center">
+                <button x-on:click="window.history.back()" class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors">
+                    Go Back
+                </button>
+                <a :href="window.parker.route('pages.home')" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors">
+                    Home
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="error" style="display: none;" class="text-center py-12">
+        <div class="bg-red-900/20 text-red-400 p-4 rounded-lg inline-block border border-red-800">
+            <p x-text="error"></p>
+        </div>
+        <div class="mt-4">
+            <button x-on:click="loadPerson()" class="text-blue-400 hover:underline">Try Again</button>
+        </div>
+    </div>
+
+    <template x-if="person && !loading && !error && !notFound">
+        <div class="space-y-10">
+            <div class="flex items-center space-x-2 text-gray-400 text-sm md:text-base">
+                <a :href="window.parker.route('pages.home')" class="py-1 hover:text-white">Home</a>
+                <span>/</span>
+                <span class="text-white" x-text="person.name"></span>
+            </div>
+
+            <section class="rounded-lg border border-gray-700 bg-gray-800 p-6 shadow-lg">
+                <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                    <div class="min-w-0">
+                        <div class="text-xs font-bold uppercase tracking-[0.2em] text-blue-300/80">Person</div>
+                        <h1 class="mt-2 text-3xl md:text-5xl font-bold text-white leading-tight" x-text="person.name"></h1>
+
+                        <div class="mt-4 flex flex-wrap gap-2 text-sm">
+                            <span class="rounded-full border border-blue-800 bg-blue-900/40 px-3 py-1 text-blue-100" x-text="issueLabel(person.total_issues)"></span>
+                            <span class="rounded-full border border-gray-600 bg-gray-900/60 px-3 py-1 text-gray-200" x-text="seriesLabel(person.total_series)"></span>
+                            <template x-if="yearRange(person)">
+                                <span class="rounded-full border border-gray-600 bg-gray-900/60 px-3 py-1 text-gray-200" x-text="yearRange(person)"></span>
+                            </template>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <template x-if="person.top_publishers?.length">
+                            <div class="flex max-w-full flex-wrap gap-2">
+                                <template x-for="publisher in person.top_publishers" :key="publisher.name">
+                                    <span class="rounded border border-gray-700 bg-gray-900 px-2.5 py-1 text-xs text-gray-300">
+                                        <span x-text="publisher.name"></span>
+                                        <span class="text-gray-500" x-text="` ${publisher.issue_count}`"></span>
+                                    </span>
+                                </template>
+                            </div>
+                        </template>
+
+                        <a :href="allRolesSearchHref()"
+                           class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-bold text-white shadow-lg transition-colors hover:bg-blue-500">
+                            View All Credits
+                        </a>
+                    </div>
+                </div>
+            </section>
+
+            <template x-for="role in person.roles" :key="role.role">
+                <section class="space-y-4">
+                    <div class="flex flex-col gap-3 border-b border-gray-700 pb-3 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h2 class="text-2xl font-bold text-white" x-text="`As ${role.label}`"></h2>
+                            <div class="mt-1 flex flex-wrap gap-2 text-sm text-gray-400">
+                                <span x-text="issueLabel(role.issue_count)"></span>
+                                <span class="text-gray-600">/</span>
+                                <span x-text="seriesLabel(role.series_count)"></span>
+                                <template x-if="yearRange(role)">
+                                    <span class="text-gray-500" x-text="yearRange(role)"></span>
+                                </template>
+                            </div>
+                        </div>
+
+                        <a x-show="isSearchableRole(role.role)"
+                           :href="roleSearchHref(role.role)"
+                           class="text-sm font-bold text-blue-400 transition-colors hover:text-blue-300">
+                            View All As <span x-text="role.label"></span>
+                        </a>
+                    </div>
+
+                    <div x-show="role.series?.length" class="flex gap-5 overflow-x-auto pb-4 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
+                        <template x-for="series in role.series" :key="`${role.role}-${series.id}`">
+                            <a :href="window.parker.route('pages.series_detail', { series_id: series.id })"
+                               class="group block w-40 flex-shrink-0">
+                                <div class="relative aspect-[2/3] overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-md transition-all duration-200 group-hover:scale-[1.02] group-hover:border-blue-500">
+                                    <template x-if="series.thumbnail_path">
+                                        <img
+                                            :src="series.thumbnail_path"
+                                            :alt="series.name"
+                                            class="h-full w-full object-cover transition-opacity duration-300"
+                                            loading="lazy"
+                                        >
+                                    </template>
+
+                                    <template x-if="!series.thumbnail_path">
+                                        <div class="flex h-full w-full items-center justify-center bg-gray-800 text-gray-600">
+                                            <span class="text-4xl">?</span>
+                                        </div>
+                                    </template>
+
+                                    <template x-if="series.read">
+                                        <div class="absolute right-2 top-2 z-10 rounded-full border border-green-400 bg-green-500 p-0.5 text-white shadow-md">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                            </svg>
+                                        </div>
+                                    </template>
+
+                                    <div class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-0 opacity-0 transition-all group-hover:bg-opacity-60 group-hover:opacity-100">
+                                        <span class="rounded-full bg-blue-600 px-3 py-1 text-sm font-bold text-white shadow-lg">View</span>
+                                    </div>
+                                </div>
+
+                                <div class="mt-2 min-w-0">
+                                    <p class="truncate text-sm font-bold text-gray-200 transition-colors group-hover:text-blue-300" x-text="series.name"></p>
+                                    <p class="truncate text-xs text-gray-500" x-text="seriesMeta(series)"></p>
+                                </div>
+                            </a>
+                        </template>
+                    </div>
+                </section>
+            </template>
+        </div>
+    </template>
+</div>
+
+<script>
+function personDetail() {
+    return {
+        personId: {{ person_id }},
+        person: null,
+        loading: true,
+        notFound: false,
+        error: null,
+        searchableRoles: ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor'],
+
+        init() {
+            this.loadPerson();
+        },
+
+        async loadPerson() {
+            this.loading = true;
+            this.error = null;
+            this.notFound = false;
+
+            try {
+                const res = await fetch(window.parker.route('people.detail', { person_id: this.personId }));
+
+                if (res.status === 404) {
+                    this.notFound = true;
+                    return;
+                }
+
+                if (!res.ok) {
+                    throw new Error('Failed to load person');
+                }
+
+                this.person = await res.json();
+                document.title = `${this.person.name} - Parker`;
+            } catch (e) {
+                console.error(e);
+                this.error = 'Could not load person details.';
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        isSearchableRole(role) {
+            return this.searchableRoles.includes(role);
+        },
+
+        roleSearchHref(role) {
+            if (!this.person?.name) {
+                return window.parker.route('pages.search');
+            }
+
+            return window.parker.searchHandoff.buildUrl({
+                match: 'all',
+                sortBy: 'series',
+                sortOrder: 'asc',
+                limit: 100,
+                filters: [{
+                    field: role,
+                    operator: 'equal',
+                    value: [this.person.name],
+                }],
+            });
+        },
+
+        allRolesSearchHref() {
+            if (!this.person?.name) {
+                return window.parker.route('pages.search');
+            }
+
+            return window.parker.searchHandoff.buildUrl({
+                match: 'any',
+                sortBy: 'series',
+                sortOrder: 'asc',
+                limit: 100,
+                filters: this.searchableRoles.map((field) => ({
+                    field,
+                    operator: 'equal',
+                    value: [this.person.name],
+                })),
+            });
+        },
+
+        issueLabel(count) {
+            const total = Number(count || 0);
+            return `${total.toLocaleString()} issue${total === 1 ? '' : 's'}`;
+        },
+
+        seriesLabel(count) {
+            const total = Number(count || 0);
+            return `${total.toLocaleString()} series`;
+        },
+
+        yearRange(item) {
+            if (!item?.start_year && !item?.end_year) {
+                return '';
+            }
+
+            if (item.start_year && item.end_year && item.start_year !== item.end_year) {
+                return `${item.start_year}-${item.end_year}`;
+            }
+
+            return item.start_year || item.end_year || '';
+        },
+
+        seriesMeta(series) {
+            const pieces = [this.issueLabel(series.issue_count)];
+            const years = this.yearRange(series);
+            if (years) pieces.push(years);
+            return pieces.join(' / ');
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -2,17 +2,19 @@
 
 Status: Draft
 
-`0.1.33` starts with a Cover Browser anchored deep-link fix for large runs, library alphabet jump navigation, and a documentation clarification for parallel thumbnail CPU configuration.
+`0.1.33` starts with a Cover Browser anchored deep-link fix for large runs, library alphabet jump navigation, dedicated person pages for creator credits, and a documentation clarification for parallel thumbnail CPU configuration.
 
 ## Added
 
 - Added `anchor_comic_id` support to the cover manifest API so comic-detail cover jumps can request the manifest window around the target issue directly.
 - Added alphabet jump navigation to library detail pages so large paginated libraries can jump directly to the page containing a selected starting letter.
+- Added dedicated person detail pages for creator credits, grouping visible work into role-specific series rails with issue counts, year ranges, publisher summaries, and Advanced Search handoffs.
 
 ## Changed
 
 - Cover Browser manifest loading now tracks the loaded window's base offset and can lazy-load previous pages as well as next pages, keeping position labels and navigation accurate when a deep link starts in the middle of a run.
 - Library alphabet jumps in infinite-scroll mode now scroll directly to a letter when that letter's page is already loaded, avoiding an unnecessary page reload.
+- Quick Search people results now open the person's overview page instead of immediately executing a creator-role Advanced Search, while individual creator role chips continue to deep-link to exact role searches.
 - README documentation now describes Parallel Thumbnail Generation `Auto` mode as using 50% of available CPU cores.
 
 ## Fixed
@@ -27,3 +29,5 @@ Status: Draft
 - Verified anchored Cover Browser manifest positioning and browser deep-link behavior: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_comics.py::test_cover_manifest_anchor_comic_id_starts_near_requested_item tests\browser\test_navigation_smoke.py::test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages -q`.
 - Verified archive page filtering, explicit cover/end-page priority, separator ordering, and same-stem base-cover precedence for numbered interior pages: `6 passed` via `.\.venv\Scripts\python.exe -m pytest tests\services\test_archive.py -q`.
 - Verified library alphabet jump anchor page/index calculation, age-restricted visibility, replace-window behavior, forward infinite-scroll continuation, and in-place scrolling when the target page is already loaded: `4 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward tests\browser\test_navigation_smoke.py::test_library_letter_jump_scrolls_without_reload_when_page_is_loaded -q`.
+- Verified person detail API visibility, person page rendering, Quick Search person handoff, and creator role-chip search handoff: `7 passed, 36 deselected`; `1 passed, 4 deselected`; `1 passed, 14 deselected` via focused API and browser pytest runs.
+- Verified the full test suite passed before merge.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -340,7 +340,6 @@ document.addEventListener('alpine:init', () => {
         results: {},
         isOpen: false,
         loading: false,
-        creatorRoleFields: ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'editor', 'cover_artist'],
 
         get hasResults() {
             return Object.values(this.results).some(arr => arr && arr.length > 0);
@@ -352,14 +351,7 @@ document.addEventListener('alpine:init', () => {
                 return window.parker.route('pages.search');
             }
 
-            return window.parker.searchHandoff.buildUrl({
-                match: 'any',
-                filters: this.creatorRoleFields.map((field) => ({
-                    field,
-                    operator: 'equal',
-                    value: [name]
-                }))
-            });
+            return window.parker.route('pages.person_detail', { person_id: item.id });
         },
 
         async fetchResults() {

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -551,13 +551,33 @@ def test_timeline_year_labels_remain_sticky_in_year_and_decade_modes(auth_client
     assert "sticky top-24 text-2xl font-black text-white" in body
 
 
-def test_search_widget_people_results_use_generic_creator_handoff(auth_client):
+def test_search_widget_people_results_use_person_detail_handoff(auth_client):
     response = auth_client.get("/")
 
     assert response.status_code == 200
     body = response.text
     assert 'personSearchHref(item)' in body
     assert 'field=writer&value=${encodeURIComponent(item.name)}&operator=contains' not in body
+
+    widget = Path("app/templates/partials/search_widget.html").read_text(encoding="utf-8")
+    assert "People" in widget
+
+
+def test_search_widget_people_results_target_person_pages():
+    script = Path("static/js/app.js").read_text(encoding="utf-8")
+
+    assert "window.parker.route('pages.person_detail', { person_id: item.id })" in script
+    assert "creatorRoleFields" not in script
+
+
+def test_person_page_renders_for_authenticated_user(auth_client):
+    response = auth_client.get("/people/123")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "personDetail()" in body
+    assert "people.detail" in body
+    assert "View All Credits" in body
 
 
 def test_advanced_search_page_exposes_full_creator_filter_set(auth_client):

--- a/tests/api/test_people.py
+++ b/tests/api/test_people.py
@@ -1,0 +1,159 @@
+from app.models.comic import Volume
+from app.models.credits import ComicCredit, Person
+from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
+
+
+def _seed_person_fixture(db, normal_user):
+    visible_library = create_library_with_root(db, "Person Visible Library", "/tmp/person-visible")
+    hidden_library = create_library_with_root(db, "Person Hidden Library", "/tmp/person-hidden")
+    visible_root = visible_library.active_root
+    hidden_root = hidden_library.active_root
+
+    writer_series = Series(name="Person Writer Run", library=visible_library)
+    art_series = Series(name="Person Art Run", library=visible_library)
+    banned_series = Series(name="Person Banned Run", library=visible_library)
+    hidden_series = Series(name="Person Hidden Run", library=hidden_library)
+    db.add_all([writer_series, art_series, banned_series, hidden_series])
+    db.flush()
+
+    writer_volume = Volume(series=writer_series, volume_number=1)
+    art_volume = Volume(series=art_series, volume_number=1)
+    banned_volume = Volume(series=banned_series, volume_number=1)
+    hidden_volume = Volume(series=hidden_series, volume_number=1)
+    db.add_all([writer_volume, art_volume, banned_volume, hidden_volume])
+    db.flush()
+
+    writer_one = create_comic(
+        db,
+        writer_volume,
+        visible_root,
+        "person-writer-1.cbz",
+        number="1",
+        title="Writer One",
+        year=1980,
+        publisher="Visible Publisher",
+        age_rating="Teen",
+        filename="person-writer-1.cbz",
+    )
+    writer_two = create_comic(
+        db,
+        writer_volume,
+        visible_root,
+        "person-writer-2.cbz",
+        number="2",
+        title="Writer Two",
+        year=1981,
+        publisher="Visible Publisher",
+        age_rating="Teen",
+        filename="person-writer-2.cbz",
+    )
+    penciller_one = create_comic(
+        db,
+        art_volume,
+        visible_root,
+        "person-art-1.cbz",
+        number="1",
+        title="Art One",
+        year=1985,
+        publisher="Art Publisher",
+        age_rating="Teen",
+        filename="person-art-1.cbz",
+    )
+    banned = create_comic(
+        db,
+        banned_volume,
+        visible_root,
+        "person-banned.cbz",
+        number="1",
+        title="Banned",
+        year=1990,
+        publisher="Banned Publisher",
+        age_rating="Mature 17+",
+        filename="person-banned.cbz",
+    )
+    hidden = create_comic(
+        db,
+        hidden_volume,
+        hidden_root,
+        "person-hidden.cbz",
+        number="1",
+        title="Hidden",
+        year=1995,
+        publisher="Hidden Publisher",
+        age_rating="Teen",
+        filename="person-hidden.cbz",
+    )
+
+    person = Person(name="Person Page Person")
+    hidden_only_person = Person(name="Hidden Only Person")
+    db.add_all([person, hidden_only_person])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=writer_one.id, person_id=person.id, role="writer"),
+        ComicCredit(comic_id=writer_one.id, person_id=person.id, role="inker"),
+        ComicCredit(comic_id=writer_two.id, person_id=person.id, role="writer"),
+        ComicCredit(comic_id=penciller_one.id, person_id=person.id, role="penciller"),
+        ComicCredit(comic_id=banned.id, person_id=person.id, role="writer"),
+        ComicCredit(comic_id=hidden.id, person_id=person.id, role="writer"),
+        ComicCredit(comic_id=hidden.id, person_id=hidden_only_person.id, role="writer"),
+    ])
+
+    normal_user.accessible_libraries.append(visible_library)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    return {
+        "person": person,
+        "hidden_only_person": hidden_only_person,
+    }
+
+
+def test_person_detail_groups_visible_credits_by_role(auth_client, db, normal_user):
+    data = _seed_person_fixture(db, normal_user)
+
+    response = auth_client.get(f"/api/people/{data['person'].id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["name"] == "Person Page Person"
+    assert payload["total_issues"] == 3
+    assert payload["total_series"] == 2
+    assert payload["start_year"] == 1980
+    assert payload["end_year"] == 1985
+    assert {row["name"] for row in payload["top_publishers"]} == {"Visible Publisher", "Art Publisher"}
+
+    roles = {row["role"]: row for row in payload["roles"]}
+    assert list(roles) == ["writer", "penciller", "inker"]
+    assert roles["writer"]["issue_count"] == 2
+    assert roles["writer"]["series_count"] == 1
+    assert roles["writer"]["series"][0]["name"] == "Person Writer Run"
+    assert roles["writer"]["series"][0]["thumbnail_path"].startswith("/api/comics/")
+    assert roles["penciller"]["issue_count"] == 1
+    assert roles["penciller"]["series"][0]["name"] == "Person Art Run"
+    assert roles["inker"]["issue_count"] == 1
+
+
+def test_person_detail_hides_people_with_no_visible_credits(auth_client, db, normal_user):
+    data = _seed_person_fixture(db, normal_user)
+
+    response = auth_client.get(f"/api/people/{data['hidden_only_person'].id}")
+
+    assert response.status_code == 404
+
+
+def test_person_detail_superuser_can_view_all_credits(admin_client, db, normal_user):
+    data = _seed_person_fixture(db, normal_user)
+
+    response = admin_client.get(f"/api/people/{data['person'].id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_issues"] == 5
+    assert payload["total_series"] == 4
+    assert payload["end_year"] == 1995
+    assert "Banned Publisher" in {row["name"] for row in payload["top_publishers"]}
+    assert "Hidden Publisher" in {row["name"] for row in payload["top_publishers"]}

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -175,6 +175,7 @@ def browser_seed_data(browser_db_factory):
         "in_progress_comic_id": in_progress_comic.id,
         "in_progress_comic_title": in_progress_comic.title,
         "in_progress_comic_number": in_progress_comic.number,
+        "writer_id": writer.id,
     }
 
     session.close()

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -448,6 +448,21 @@ def test_quick_search_navigates_to_reading_list(page, browser_server):
 
 
 @pytest.mark.browser
+def test_creator_role_chip_still_opens_role_search(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(
+        f"{browser_server['base_url']}/comics/{seed['in_progress_comic_id']}",
+        wait_until="networkidle",
+    )
+
+    page.get_by_role("heading", name=f"{seed['series_name']} #{seed['in_progress_comic_number']}").wait_for()
+    page.get_by_role("link", name="Casey Smoke").click()
+
+    page.wait_for_url("**/search?field=writer&value=Casey%20Smoke&operator=equal")
+    page.get_by_role("heading", name="Advanced Search").wait_for()
+
+
+@pytest.mark.browser
 def test_library_timeline_deep_link_shows_character_history_and_search_handoff(page, browser_server):
     seed = browser_server["seed"]
     page.goto(

--- a/tests/browser/test_reader_contract_smoke.py
+++ b/tests/browser/test_reader_contract_smoke.py
@@ -88,27 +88,24 @@ def test_reader_incognito_does_not_persist_progress(page, browser_server):
 
 
 @pytest.mark.browser
-def test_quick_search_person_result_opens_filtered_search(page, browser_server):
+def test_quick_search_person_result_opens_person_page(page, browser_server):
     seed = browser_server["seed"]
     page.goto(f"{browser_server['base_url']}/", wait_until="networkidle")
 
     search_input = page.locator("nav input[type='search']").first
     search_input.fill("Casey")
 
-    page.locator("text=People").first.wait_for()
-    page.get_by_role("link", name="Casey Smoke").first.click()
+    person_link = page.get_by_role("link", name="Casey Smoke").first
+    person_link.wait_for()
+    person_link.click()
 
-    page.wait_for_url("**/search?*")
-    assert "filters=" in page.url
+    page.wait_for_url(f"**/people/{seed['writer_id']}")
+    page.get_by_role("heading", name="Casey Smoke").wait_for()
+    page.get_by_role("heading", name="As Writer").wait_for()
 
-    results_section = page.locator("div[x-show='hasSearched']")
-    results_section.wait_for()
-    page.wait_for_selector("text=Results")
-    result_title = results_section.locator("p.text-sm.text-gray-400").filter(
-        has_text=seed["in_progress_comic_title"]
-    ).first
-    result_title.wait_for()
-    assert result_title.is_visible()
+    page.get_by_role("link", name="View All As Writer").click()
+    page.wait_for_url("**/search*")
+    page.get_by_role("heading", name="Advanced Search").wait_for()
 
 
 @pytest.mark.browser


### PR DESCRIPTION
## Summary

- Added dedicated person detail pages for creator credits at `/people/{person_id}`.
- Added a `/api/people/{person_id}` endpoint that groups visible creator credits by role and returns series-level rails with issue counts, year ranges, publisher summaries, cover thumbnails, and read state.
- Updated Quick Search people results to open the new person overview page instead of immediately executing an Advanced Search.
- Preserved creator role chip behavior so clicking a role-specific credit still opens Advanced Search filtered to that person and role.
- Updated README and `0.1.33` release notes.

## Validation

- Focused API/page coverage passed: `7 passed, 36 deselected`.
- Quick Search person browser coverage passed: `1 passed, 4 deselected`.
- Creator role-chip browser coverage passed: `1 passed, 14 deselected`.
- Full test suite passed before merge.