### PR TITLE
Introduce Lucide-style Home rail icons

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Home - Parker{% endblock %}
 
+{% from "partials/lucide_icon.html" import lucide_icon %}
+
 {% block content %}
 <div class="space-y-12" x-data='homePage({{ {"startupNotice": startup_notice}|tojson }})'>
 
@@ -25,7 +27,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">&#9658;</span> Jump Back In
+                                    {{ lucide_icon("book-open", "h-5 w-5 flex-shrink-0 text-blue-300") }} Jump Back In
                                 </h2>
                             </div>
 
@@ -43,7 +45,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">+</span> New from Following
+                                    {{ lucide_icon("plus-circle", "h-5 w-5 flex-shrink-0 text-emerald-300") }} New from Following
                                 </h2>
                                 <a :href="window.parker.route('pages.user_following')" class="text-xs text-blue-400 hover:text-white transition-colors">
                                     Manage Following
@@ -64,7 +66,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">&#9654;</span> Up Next
+                                    {{ lucide_icon("circle-play", "h-5 w-5 flex-shrink-0 text-sky-300") }} Up Next
                                 </h2>
                             </div>
                             <div class="flex space-x-4 overflow-x-auto pb-6 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
@@ -80,7 +82,9 @@
                     <template x-if="rail.key === 'pinned_libraries'">
                         <section class="space-y-12">
                             <div class="flex items-center justify-between border-b border-gray-700 pb-2">
-                                <h2 class="text-xl font-bold text-white">Pinned Libraries</h2>
+                                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                                    {{ lucide_icon("library", "h-5 w-5 flex-shrink-0 text-indigo-300") }} Pinned Libraries
+                                </h2>
                                 <a :href="window.parker.route('pages.libraries')" class="text-xs text-blue-400 hover:text-white transition-colors">Manage Pins</a>
                             </div>
 
@@ -132,7 +136,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span class="text-yellow-400" aria-hidden="true">&#9733;</span> Want to Read
+                                    {{ lucide_icon("star", "h-5 w-5 flex-shrink-0 text-yellow-400") }} Want to Read
                                 </h2>
                             </div>
 
@@ -148,7 +152,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span class="text-yellow-400" aria-hidden="true">&#9733;</span> Critically Acclaimed
+                                    {{ lucide_icon("award", "h-5 w-5 flex-shrink-0 text-yellow-400") }} Critically Acclaimed
                                 </h2>
                             </div>
 
@@ -166,7 +170,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span class="text-blue-400" aria-hidden="true">&#9733;</span> Top Rated on Parker
+                                    {{ lucide_icon("star", "h-5 w-5 flex-shrink-0 text-blue-400") }} Top Rated on Parker
                                 </h2>
                             </div>
 
@@ -184,7 +188,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">&#9889;</span> Trending
+                                    {{ lucide_icon("zap", "h-5 w-5 flex-shrink-0 text-amber-300") }} Trending
                                 </h2>
                             </div>
 
@@ -200,7 +204,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">&#8593;</span> Popular with Others
+                                    {{ lucide_icon("flame", "h-5 w-5 flex-shrink-0 text-orange-300") }} Popular with Others
                                 </h2>
                             </div>
 
@@ -216,7 +220,7 @@
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                                    <span aria-hidden="true">?</span> Random Gems
+                                    {{ lucide_icon("dice-5", "h-5 w-5 flex-shrink-0 text-violet-300") }} Random Gems
                                 </h2>
                                 <button x-on:click="fetchRandom(false)" class="text-xs text-blue-400 hover:text-white">Spin Again</button>
                             </div>
@@ -232,8 +236,8 @@
                     <template x-if="rail.key === 'recently_added_series'">
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
-                                <h2 class="text-xl font-bold text-white">
-                                    <span aria-hidden="true">+</span> Recently Added Series
+                                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                                    {{ lucide_icon("sparkles", "h-5 w-5 flex-shrink-0 text-cyan-300") }} Recently Added Series
                                 </h2>
                                 <a :href="window.parker.route('pages.search', {}, 'sort_by=created&sort_order=desc')" class="text-sm text-blue-400 hover:text-white transition-colors">View All</a>
                             </div>
@@ -249,8 +253,8 @@
                     <template x-if="rail.key === 'recently_updated_series'">
                         <section>
                             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
-                                <h2 class="text-xl font-bold text-white">
-                                    <span aria-hidden="true">&#8635;</span> Recently Updated Series
+                                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                                    {{ lucide_icon("refresh-cw", "h-5 w-5 flex-shrink-0 text-teal-300") }} Recently Updated Series
                                 </h2>
                                 <a :href="window.parker.route('pages.search', {}, 'sort_by=updated&sort_order=desc')" class="text-sm text-blue-400 hover:text-white transition-colors">View All</a>
                             </div>

--- a/app/templates/partials/lucide_icon.html
+++ b/app/templates/partials/lucide_icon.html
@@ -1,0 +1,59 @@
+{% macro lucide_icon(name, classes="h-5 w-5") -%}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="{{ classes }}"
+    aria-hidden="true"
+    focusable="false"
+    data-lucide-icon="{{ name }}"
+>
+    {% if name == "award" %}
+        <circle cx="12" cy="8" r="6"></circle>
+        <path d="M15.477 12.89 17 21.5l-5-3-5 3 1.523-8.61"></path>
+    {% elif name == "book-open" %}
+        <path d="M12 7v14"></path>
+        <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path>
+    {% elif name == "circle-play" %}
+        <circle cx="12" cy="12" r="10"></circle>
+        <polygon points="10 8 16 12 10 16 10 8"></polygon>
+    {% elif name == "dice-5" %}
+        <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
+        <path d="M16 8h.01"></path>
+        <path d="M8 8h.01"></path>
+        <path d="M8 16h.01"></path>
+        <path d="M16 16h.01"></path>
+        <path d="M12 12h.01"></path>
+    {% elif name == "flame" %}
+        <path d="M8.5 14.5A2.5 2.5 0 0 0 11 17c1.38 0 2.5-1.12 2.5-2.5 0-.84-.43-1.58-1.08-2.04-.97-.69-1.65-1.82-1.65-3.16 0-1.61.95-2.99 2.31-3.63.31 2.3 1.96 3.76 3.19 5.14 1.22 1.37 1.73 2.74 1.73 4.19a6 6 0 1 1-12 0c0-1.47.52-2.86 1.73-4.19.6-.66 1.23-1.32 1.77-2.07.05 2.24-1.03 3.84-1 5.76z"></path>
+    {% elif name == "library" %}
+        <path d="m16 6 4 14"></path>
+        <path d="M12 6v14"></path>
+        <path d="M8 8v12"></path>
+        <path d="M4 4v16"></path>
+    {% elif name == "plus-circle" %}
+        <circle cx="12" cy="12" r="10"></circle>
+        <path d="M8 12h8"></path>
+        <path d="M12 8v8"></path>
+    {% elif name == "refresh-cw" %}
+        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"></path>
+        <path d="M21 3v5h-5"></path>
+        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"></path>
+        <path d="M8 16H3v5"></path>
+    {% elif name == "sparkles" %}
+        <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"></path>
+        <path d="M20 3v4"></path>
+        <path d="M22 5h-4"></path>
+        <path d="M4 17v2"></path>
+        <path d="M5 18H3"></path>
+    {% elif name == "star" %}
+        <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.751a.53.53 0 0 1 .294.904l-3.736 3.641a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.77.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0l-4.618 2.428a.53.53 0 0 1-.77-.56l.882-5.14a2.122 2.122 0 0 0-.611-1.878L2.16 9.79a.53.53 0 0 1 .294-.904l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"></path>
+    {% elif name == "zap" %}
+        <path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"></path>
+    {% endif %}
+</svg>
+{%- endmacro %}

--- a/docs/releases/0.1.33.md
+++ b/docs/releases/0.1.33.md
@@ -9,10 +9,12 @@ Status: Draft
 - Added `anchor_comic_id` support to the cover manifest API so comic-detail cover jumps can request the manifest window around the target issue directly.
 - Added alphabet jump navigation to library detail pages so large paginated libraries can jump directly to the page containing a selected starting letter.
 - Added dedicated person detail pages for creator credits, grouping visible work into role-specific series rails with issue counts, year ranges, publisher summaries, and Advanced Search handoffs.
+- Added a reusable inline Lucide icon partial for stable SVG iconography without adding a browser-side package dependency.
 
 ## Changed
 
 - Cover Browser manifest loading now tracks the loaded window's base offset and can lazy-load previous pages as well as next pages, keeping position labels and navigation accurate when a deep link starts in the middle of a run.
+- Home rail headings now use subtle Lucide SVG icons instead of emoji or text glyph markers for more consistent cross-platform sizing.
 - Library alphabet jumps in infinite-scroll mode now scroll directly to a letter when that letter's page is already loaded, avoiding an unnecessary page reload.
 - Quick Search people results now open the person's overview page instead of immediately executing a creator-role Advanced Search, while individual creator role chips continue to deep-link to exact role searches.
 - README documentation now describes Parallel Thumbnail Generation `Auto` mode as using 50% of available CPU cores.
@@ -29,6 +31,7 @@ Status: Draft
 
 - Verified anchored Cover Browser manifest positioning and browser deep-link behavior: `2 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_comics.py::test_cover_manifest_anchor_comic_id_starts_near_requested_item tests\browser\test_navigation_smoke.py::test_cover_browser_deep_link_anchors_without_walking_prior_manifest_pages -q`.
 - Verified archive page filtering/sorting, `00fc` reader page selection, and reader init page cache-key emission: `9 passed` via `.\.venv\Scripts\python.exe -m pytest tests\services\test_archive.py tests\api\test_reader.py::test_reader_init_default_volume_reverse_and_page_count_fallback tests\api\test_reader.py::test_reader_page_endpoint_serves_zero_fc_cover_as_first_page -q`.
+- Verified Home renders Lucide SVG rail heading icons, no longer uses the previous emoji/text glyph rail markers, and preserves Home customization browser flows: `1 passed`; `3 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_pages.py::test_home_page_uses_lucide_rail_heading_icons -q` and `.\.venv\Scripts\python.exe -m pytest tests\browser\test_home_customization.py -q`.
 - Verified library alphabet jump anchor page/index calculation, age-restricted visibility, replace-window behavior, forward infinite-scroll continuation, and in-place scrolling when the target page is already loaded: `4 passed` via `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py::test_get_library_series_letter_anchors_use_library_sort_pages tests\api\test_libraries.py::test_get_library_series_filters_by_age_restriction tests\browser\test_navigation_smoke.py::test_library_letter_jump_replaces_infinite_window_and_continues_forward tests\browser\test_navigation_smoke.py::test_library_letter_jump_scrolls_without_reload_when_page_is_loaded -q`.
 - Verified person detail API visibility, person page rendering, Quick Search person handoff, and creator role-chip search handoff: `7 passed, 36 deselected`; `1 passed, 4 deselected`; `1 passed, 14 deselected` via focused API and browser pytest runs.
 - Verified the full test suite passed before merge.

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -78,6 +78,31 @@ def test_home_page_keeps_normal_onboarding_when_startup_state_is_healthy(admin_c
     assert '{"startupNotice": null}' in body
 
 
+def test_home_page_uses_lucide_rail_heading_icons(auth_client):
+    response = auth_client.get("/")
+
+    assert response.status_code == 200
+    body = response.text
+    for icon_name in [
+        "book-open",
+        "plus-circle",
+        "circle-play",
+        "library",
+        "star",
+        "award",
+        "zap",
+        "flame",
+        "dice-5",
+        "sparkles",
+        "refresh-cw",
+    ]:
+        assert f'data-lucide-icon="{icon_name}"' in body
+
+    assert "Random Gems" in body
+    assert "<span aria-hidden=\"true\">?</span> Random Gems" not in body
+    assert "&#9889;</span> Trending" not in body
+
+
 def test_home_page_shows_legacy_default_password_warning_for_admin(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.pages.collect_startup_diagnostics",


### PR DESCRIPTION

**Description**
Adds a small reusable inline SVG partial for Lucide-style icons and updates the Home page rail headings to use consistent SVG iconography instead of emoji/text glyph markers. This keeps the visual treatment cleaner and more platform-stable without adding a browser-side Lucide package, CDN dependency, or frontend build step.

Smart-list icons remain data-driven so user-configured Home rail icons are unchanged.

**Changes**
- Added a reusable `lucide_icon` Jinja macro for the small current icon subset.
- Replaced Home page rail heading emoji/glyph markers with Lucide-style SVG equivalents.
- Added release notes for the new icon treatment in `0.1.33`.
- Added API coverage to confirm Home renders the expected Lucide icons and no longer uses the old rail markers.

**Validation**
- `.\.venv\Scripts\python.exe -m pytest tests\api\test_pages.py::test_home_page_uses_lucide_rail_heading_icons -q`
- `.\.venv\Scripts\python.exe -m pytest tests\browser\test_home_customization.py -q`